### PR TITLE
pages.rs: fix run of orphans packages

### DIFF
--- a/src/pages.rs
+++ b/src/pages.rs
@@ -65,7 +65,17 @@ fn create_fixes_section() -> gtk::Box {
     remove_orphans_btn.connect_clicked(move |_| {
         // Spawn child process in separate thread.
         std::thread::spawn(move || {
-            let _ = utils::run_cmd_terminal(String::from("pacman -Rns $(pacman -Qtdq)"), true);
+            // check if you have orphans packages.
+            let status = std::process::Command::new("pacman")
+                     .arg("-Qtdq")
+                     .status()
+                     .expect("Found orphans packages");
+
+            if status.success() {
+                let _ = utils::run_cmd_terminal(String::from("pacman -Rns $(pacman -Qtdq)"), true);
+            } else {
+                let _ = utils::run_cmd_terminal(String::from("echo 'Not orphans packages'"), false);
+            }
         });
     });
     clear_pkgcache_btn.connect_clicked(on_clear_pkgcache_btn_clicked);

--- a/src/pages.rs
+++ b/src/pages.rs
@@ -67,9 +67,9 @@ fn create_fixes_section() -> gtk::Box {
         std::thread::spawn(move || {
             // check if you have orphans packages.
             let status = std::process::Command::new("pacman")
-                     .arg("-Qtdq")
-                     .status()
-                     .expect("Found orphans packages");
+                .arg("-Qtdq")
+                .status()
+                .expect("Found orphans packages");
 
             if status.success() {
                 let _ = utils::run_cmd_terminal(String::from("pacman -Rns $(pacman -Qtdq)"), true);


### PR DESCRIPTION
This avoid "error: no targets specified (use -h for help)" when `pacman -Qtdq` is empty.

`pacman -Qtdq` can be started without root, and has a return value other than 0 if it finds no packages. So if it finds packages, it succeeds and goes to the true condition that it deletes packages. Otherwise do echo. (echo doesn't require root)