### PR TITLE
installer: Compare ISO versions naturally

### DIFF
--- a/src/installer.rs
+++ b/src/installer.rs
@@ -56,7 +56,7 @@ fn outdated_version_check(window: &gtk::Window, message: String) -> bool {
     .trim()
     .to_owned();
 
-    if version_tag != latest_version {
+    if version_tag.parse::<i32>().unwrap() < latest_version.parse::<i32>().unwrap() {
         utils::show_simple_dialog(
             window,
             gtk::MessageType::Warning,


### PR DESCRIPTION
Otherwise warning will be displayed even for ISOs that are actually newer than latest version, e.g. for locally built ISOs.