### PR TITLE
terminal-helper: Fix unavailability of gnome-console

### DIFF
--- a/src/scripts/terminal-helper
+++ b/src/scripts/terminal-helper
@@ -50,7 +50,7 @@ declare -A terminals=(
     ["alacritty"]="alacritty -e $cmd || LIBGL_ALWAYS_SOFTWARE=1 alacritty -e $cmd"
     ["foot"]="foot $cmd"
     ["ghostty"]="ghostty -e $cmd"
-    ["gnome-console"]="kgx --wait -e $cmd"
+    ["kgx"]="kgx --wait -e $cmd"
     ["gnome-terminal"]="gnome-terminal --wait -- $cmd"
     ["kitty"]="kitty $cmd"
     ["konsole"]="konsole -e $cmd"
@@ -66,7 +66,7 @@ declare -a term_order=(
     "ghostty"
     "kitty"
     "konsole"
-    "gnome-console"
+    "kgx"
     "gnome-terminal"
     "xfce4-terminal"
     "lxterminal"
@@ -78,6 +78,9 @@ declare -a term_order=(
 if [ -z "$terminal" ] || ! command -v "$terminal" &>/dev/null; then
     for entry in "${term_order[@]}"; do
         if command -v "$entry" >/dev/null 2>&1; then
+            # gnome-console does not exit on command completion so we need to kill
+            # it manually
+            [[ "$entry" == "kgx" ]] && echo "kill -SIGQUIT \$PPID 2>/dev/null" >> "$file"
             terminal="$entry"
             break
         fi
@@ -89,8 +92,10 @@ if [ -z "$terminal" ]; then
     exit 1
 fi
 
-eval "${terminals[${terminal}]}" || {
-    rm "$file"
-    exit 2
+eval "${terminals[${terminal}]}" 2>/dev/null || {
+    if [[ "$terminal" != "kgx" ]]; then
+        rm "$file"
+        exit 2
+    fi
 }
 rm "$file"


### PR DESCRIPTION
There's no such binary as `gnome-console` and only the `kgx`, so it leads to an error like gnome-console is not available for use.

Fixes: https://github.com/CachyOS/CachyOS-Welcome/issues/107