### PR TITLE
installer: Add fallback ping checks for the internet check

### DIFF
--- a/src/installer.rs
+++ b/src/installer.rs
@@ -114,7 +114,7 @@ fn connectivity_check(window: &gtk::Window, message: String) -> bool {
             .args(&["-c", "1", "-W", "3", target])
             .join();
             
-        if let Ok(capture) = ping_result {
+        if let Ok(status) = ping_result {
             if capture.exit_status.success() {
                 info!("Connectivity confirmed via ping to {}", target);
                 return true;

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -96,16 +96,35 @@ fn edition_compat_check(window: &gtk::Window, message: String) -> bool {
 }
 
 fn connectivity_check(window: &gtk::Window, message: String) -> bool {
-    let status = match reqwest::blocking::get("https://cachyos.org") {
+    // First try HTTP check to cachyos.org
+    let http_status = match reqwest::blocking::get("https://cachyos.org") {
         Ok(resp) => resp.status().is_success() || resp.status().is_server_error(),
         _ => false,
     };
 
-    if !status {
-        utils::show_simple_dialog(window, gtk::MessageType::Error, &fl!("offline-error"), message);
-        return false;
+    if http_status {
+        return true;
     }
-    true
+
+    // If HTTP check fails, try ping fallback to reliable DNS servers
+    let ping_targets = ["8.8.8.8", "1.1.1.1", "9.9.9.9"];
+    
+    for target in &ping_targets {
+        let ping_result = Exec::cmd("ping")
+            .args(&["-c", "1", "-W", "3", target])
+            .capture();
+            
+        if let Ok(capture) = ping_result {
+            if capture.exit_status.success() {
+                info!("Connectivity confirmed via ping to {}", target);
+                return true;
+            }
+        }
+    }
+
+    // All connectivity checks failed
+    utils::show_simple_dialog(window, gtk::MessageType::Error, &fl!("offline-error"), message);
+    false
 }
 
 pub fn launch_installer(message: String) {

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -109,7 +109,7 @@ fn connectivity_check(window: &gtk::Window, message: String) -> bool {
     // If HTTP check fails, try ping fallback to reliable DNS servers
     let ping_targets = ["8.8.8.8", "1.1.1.1", "9.9.9.9"];
     
-    for target in &ping_targets {
+    for target in ["8.8.8.8", "1.1.1.1", "9.9.9.9"] {
         let ping_result = Exec::cmd("ping")
             .args(&["-c", "1", "-W", "3", target])
             .capture();

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -116,7 +116,7 @@ fn connectivity_check(window: &gtk::Window, message: String) -> bool {
             
         if let Ok(status) = ping_result {
             if status.success() {
-                info!("Connectivity confirmed via ping to {}", target);
+                info!("Connectivity confirmed via ping to {target}");
                 return true;
             }
         }

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -108,7 +108,7 @@ fn connectivity_check(window: &gtk::Window, message: String) -> bool {
 
     // If HTTP check fails, try ping fallback to reliable DNS servers
     
-    for target in ["8.8.8.8", "1.1.1.1", "9.9.9.9"] {
+    for target in ["2001:4860:4860::8888", "2606:4700:4700::1111", "2620:fe::fe", "8.8.8.8", "1.1.1.1", "9.9.9.9"] {
         let ping_result = Exec::cmd("ping")
             .args(&["-c", "1", "-W", "3", target])
             .join();

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -112,7 +112,7 @@ fn connectivity_check(window: &gtk::Window, message: String) -> bool {
     for target in ["8.8.8.8", "1.1.1.1", "9.9.9.9"] {
         let ping_result = Exec::cmd("ping")
             .args(&["-c", "1", "-W", "3", target])
-            .capture();
+            .join();
             
         if let Ok(capture) = ping_result {
             if capture.exit_status.success() {

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -115,7 +115,7 @@ fn connectivity_check(window: &gtk::Window, message: String) -> bool {
             .join();
             
         if let Ok(status) = ping_result {
-            if capture.exit_status.success() {
+            if status.success() {
                 info!("Connectivity confirmed via ping to {}", target);
                 return true;
             }

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -107,7 +107,6 @@ fn connectivity_check(window: &gtk::Window, message: String) -> bool {
     }
 
     // If HTTP check fails, try ping fallback to reliable DNS servers
-    let ping_targets = ["8.8.8.8", "1.1.1.1", "9.9.9.9"];
     
     for target in ["8.8.8.8", "1.1.1.1", "9.9.9.9"] {
         let ping_result = Exec::cmd("ping")


### PR DESCRIPTION
In censored countries it is often not possible to ping "cachyos.org" since we are using cloudflare proxy for the website.

Add a fallback ping of 1.1.1.1 (Cloudflare), 8.8.8.8 (Cloudflare), 9.9.9.9 (Quad 9) for the internet check