### PR TITLE
Fix the openshot package

### DIFF
--- a/data/application_utility/default.json
+++ b/data/application_utility/default.json
@@ -583,7 +583,7 @@
                 "name": "Openshot",
                 "icon": "openshot",
                 "description": "Award-winning free and open-source video editor",
-                "pkg": "obs-studio",
+                "pkg": "openshot",
                 "extra": []
             },
             {


### PR DESCRIPTION
Discovered in https://discuss.cachyos.org/t/cachyos-hello-installs-obs-studio-instead-of-openshot/15555.