### PR TITLE
GTK-3 UI improvements

### DIFF
--- a/src/scripts/terminal-helper
+++ b/src/scripts/terminal-helper
@@ -99,3 +99,5 @@ eval "${terminals[${terminal}]}" 2>/dev/null || {
     fi
 }
 rm "$file"
+
+### to do : add ptyxis support ( i cant seem to do it)

--- a/src/window.rs
+++ b/src/window.rs
@@ -27,6 +27,11 @@ impl HelloWindow {
         preferences: serde_json::Value,
         best_locale: &str,
     ) -> Self {
+        // Set dark theme preference
+        if let Some(settings) = gtk::Settings::default() {
+            settings.set_property("gtk-application-prefer-dark-theme", true);
+        }
+
         // Import Css
         let provider = gtk::CssProvider::new();
         provider.load_from_resource(&format!("{RESPREFIX}/ui/style.css"));

--- a/ui/cachyos-hello.glade
+++ b/ui/cachyos-hello.glade
@@ -382,6 +382,9 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="homogeneous">True</property>
+                <property name="spacing">10</property>
+                <property name="margin-start">0</property>
+                <property name="margin-end">0</property>
                 <child>
                   <object class="GtkButton" id="tweaksBrowser">
                     <property name="label" translatable="yes">Apps/Tweaks</property>
@@ -389,8 +392,6 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                     <property name="can-focus">False</property>
                     <property name="receives-default">True</property>
                     <property name="tooltip-text" translatable="yes">Apps/Tweaks</property>
-                    <property name="margin-left">15</property>
-                    <property name="margin-right">15</property>
                     <signal name="clicked" handler="on_btn_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -406,8 +407,6 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                     <property name="can-focus">False</property>
                     <property name="receives-default">True</property>
                     <property name="tooltip-text" translatable="yes">Common application selection</property>
-                    <property name="margin-left">15</property>
-                    <property name="margin-right">15</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/ui/style.css
+++ b/ui/style.css
@@ -1,6 +1,8 @@
 window {
     border-bottom-left-radius: 7px;
     border-bottom-right-radius: 7px;
+    background-color: #1d1d1d;  /* Darker than default Adwaita dark */
+    color: #e0e0e0;
 }
 
 #tweaksBrowserpage button {
@@ -24,4 +26,6 @@ window {
 
 .aboutdialog {
     border-radius: 7px;
+    background-color: #1d1d1d;
+    color: #e0e0e0;
 }


### PR DESCRIPTION
fixed visibility of text , fixed looks , fixed margins of bottom buttons to fit the theme and layout
fixed cachyos using gtk 3 light theme by default and not using dark-theme even when theming is set to dark.

1. dark one is how it looks after pr 
2. light one is how it looks ( its hard coded light for some reason ( dosent follow the dark theme ) 

<img width="808" height="632" alt="Screenshot From 2025-09-15 13-15-29" src="https://github.com/user-attachments/assets/e10327bf-77d7-4b49-bcca-c34ecbf5b93e" />
<img width="808" height="632" alt="Screenshot From 2025-09-15 13-15-35" src="https://github.com/user-attachments/assets/1a64e3fa-940a-4de5-b551-0d6a5362c8f8" />
