### PR TITLE
Fix: Prevent unnecessary terminal spawning and respect TERMINAL env var

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -1,4 +1,5 @@
 use crate::ui::{MessageType, UI};
+use crate::utils;
 use gtk::prelude::*;
 
 pub struct GUI {
@@ -38,6 +39,20 @@ impl UI for GUI {
 }
 
 pub fn run_command(command: &str, escalate: bool) -> bool {
+    // For simple operations that don't need user interaction, run directly without terminal
+    // This prevents unnecessary terminal windows for operations like systemctl enable/disable
+    // Check if command is a simple systemctl enable/disable operation
+    let is_simple_command = command.trim_start().starts_with("systemctl") 
+        && (command.contains(" enable ") || command.contains(" disable "))
+        && !command.contains("status")  // status commands might need output
+        && !command.contains("log");     // log commands need output
+    
+    if is_simple_command {
+        // Run directly without spawning a terminal window
+        return utils::run_cmd(command.to_string(), escalate).map(|s| s.success()).unwrap_or(false);
+    }
+    
+    // For operations that may need user interaction or output viewing, use terminal
     let cmd_formated = format!("{command}; read -p 'Press enter to exit'");
     let mut args: Vec<&str> = vec![];
     if escalate {

--- a/src/scripts/rootshell.sh
+++ b/src/scripts/rootshell.sh
@@ -1,3 +1,12 @@
 #!/bin/bash
+# Modified to run commands directly without spawning a terminal
+# This allows pkexec to show authentication popup without terminal window
 
-exec bash $@
+# If arguments are provided, execute them directly as a command
+if [ $# -gt 0 ]; then
+    # Execute the command directly without spawning interactive shell
+    exec bash -c "$*"
+else
+    # If no arguments, just run bash non-interactively (should not happen)
+    exec bash --norc --noprofile
+fi

--- a/src/scripts/terminal-helper
+++ b/src/scripts/terminal-helper
@@ -60,6 +60,7 @@ declare -A terminals=(
     ["terminator"]="terminator -x $cmd"
     ["xfce4-terminal"]="xfce4-terminal --disable-server --command '$cmd'"
     ["xterm"]="xterm -e $cmd"
+    ["x-terminal-emulator"]="x-terminal-emulator -e $cmd"
 )
 declare -a term_order=(
     "alacritty"
@@ -77,6 +78,17 @@ declare -a term_order=(
     "terminator"
 )
 
+# Check $TERMINAL environment variable first (as per invariants)
+if [ -n "$TERMINAL" ] && command -v "$TERMINAL" >/dev/null 2>&1; then
+    terminal="$TERMINAL"
+fi
+
+# Check x-terminal-emulator second (distribution-specific mechanism)
+if [ -z "$terminal" ] && command -v x-terminal-emulator >/dev/null 2>&1; then
+    terminal="x-terminal-emulator"
+fi
+
+# Fall back to hardcoded list if neither $TERMINAL nor x-terminal-emulator worked
 if [ -z "$terminal" ] || ! command -v "$terminal" &>/dev/null; then
     for entry in "${term_order[@]}"; do
         if command -v "$entry" >/dev/null 2>&1; then
@@ -94,10 +106,20 @@ if [ -z "$terminal" ]; then
     exit 1
 fi
 
-eval "${terminals[${terminal}]}" 2>/dev/null || {
-    if [[ "$terminal" != "kgx" ]]; then
+# Execute the terminal command
+if [ -n "${terminals[${terminal}]}" ]; then
+    # Terminal is in our predefined list, use the configured command
+    eval "${terminals[${terminal}]}" 2>/dev/null || {
+        if [[ "$terminal" != "kgx" ]]; then
+            rm "$file"
+            exit 2
+        fi
+    }
+else
+    # Terminal is not in our list (e.g., from $TERMINAL env var), use generic -e flag
+    eval "$terminal -e $cmd" 2>/dev/null || {
         rm "$file"
         exit 2
-    fi
-}
+    }
+fi
 rm "$file"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -132,6 +132,7 @@ pub fn run_cmd_terminal(callback: RunCmdCallback, cmd: String, escalate: bool) -
 
 pub fn run_cmd(cmd: String, escalate: bool) -> anyhow::Result<ExitStatus> {
     if escalate {
+        // pkexec bash -c doesn't spawn a terminal, just shows auth dialog
         Ok(Exec::cmd("/sbin/pkexec").arg("bash").arg("-c").arg(cmd).join()?)
     } else {
         Ok(Exec::cmd("/sbin/bash").arg("-c").arg(cmd).join()?)


### PR DESCRIPTION
- Modified terminal-helper to check $TERMINAL and x-terminal-emulator first
- Updated rootshell.sh to execute commands directly without spawning terminals
- Modified gui.rs to detect simple systemctl commands and run them without terminals
- Added comment to utils.rs clarifying pkexec behavior

This fixes issues where authentication dialogs and simple operations like enabling/disabling systemd services were spawning unnecessary terminal windows. The changes ensure user terminal preferences are respected while preventing terminal spawning for operations that don't require user interaction.