### PR TITLE
Fix Tweak status detection for multi-service units

### DIFF
--- a/src/pages/tweaks.rs
+++ b/src/pages/tweaks.rs
@@ -71,12 +71,18 @@ fn set_tweak_check_data(check_btn: &gtk::CheckButton, tweak_name: TweakName) {
 }
 
 fn connect_tweak(check_btn: &gtk::CheckButton, action_data: &'static str) {
-    let action_data_str = action_data.to_owned();
-    if G_LOCAL_UNITS.lock().unwrap().enabled_units.contains(&action_data_str)
-        || G_GLOBAL_UNITS.lock().unwrap().enabled_units.contains(&action_data_str)
-    {
+    let local_guard = G_LOCAL_UNITS.lock().unwrap();
+    let global_guard = G_GLOBAL_UNITS.lock().unwrap();
+
+    let is_enabled = action_data.split_whitespace().all(|unit| {
+        local_guard.enabled_units.contains(&unit.to_string()) || 
+        global_guard.enabled_units.contains(&unit.to_string())
+    });
+
+    if is_enabled {
         check_btn.set_active(true);
     }
+    
     connect_clicked_and_save(check_btn, on_servbtn_clicked);
 }
 

--- a/src/pages/tweaks.rs
+++ b/src/pages/tweaks.rs
@@ -75,7 +75,7 @@ fn connect_tweak(check_btn: &gtk::CheckButton, action_data: &'static str) {
     let global_guard = G_GLOBAL_UNITS.lock().unwrap();
 
     let is_enabled = action_data.split_whitespace().all(|unit| {
-        local_guard.enabled_units.contains(&unit.to_string()) || 
+        local_guard.enabled_units.contains(&unit.to_string()) ||
         global_guard.enabled_units.contains(&unit.to_string())
     });
 


### PR DESCRIPTION
### Description

This PR fixes an issue where certain tweaks (specifically **Cachy Update enabled**) would always appear as "disabled" in the UI upon startup, even if the underlying systemd services/timers were active. Issue got also reported by the CachyOS discord server members under this forum thread: https://canary.discord.com/channels/862292009423470592/1420290157923274807

https://github.com/user-attachments/assets/bfa27891-9256-4d03-8a3a-c3cf00a8c7a3


### The Problem

In `src/tweak.rs`, the `CachyUpdate` tweak is defined with multiple units: `"arch-update.timer arch-update-tray.service"`.
The previous implementation in `connect_tweak` (in `src/pages/tweaks.rs`) was checking if the `enabled_units` collection contained the entire string as a single entry. Since systemd reports these as individual units, the check would always return `false`.

### The Fix

Updated `connect_tweak` to:

1. Split the `action_data` string by whitespace to handle tweaks with multiple units.
2. Check if **all** required units for a given tweak are present in either the local or global enabled units list.
3. Correctly handle string type matching (`&String` vs `&str`) to satisfy the Rust compiler.

### Verification Results

* [x] Verified that the "Cachy Update" checkbox now correctly reflects the system state on application launch.
* [x] Confirmed that the fix doesn't break single-unit tweaks (like Bluetooth or OOMD).
* [x] Code compiles successfully without warnings related to this file.

### Test Environment
* CachyOS 6.18.6-2
* Hyprland
* https://github.com/caelestia-dots/shell