### PR TITLE
Tweaks: Add Install winboat button

### DIFF
--- a/i18n/en/cachyos_hello.ftl
+++ b/i18n/en/cachyos_hello.ftl
@@ -12,6 +12,7 @@ orphans-not-found = No orphan packages found!
 package-not-installed = Package '{$package_name}' has not been installed!
 gaming-package-installed = Gaming packages already installed!
 snapper-package-installed = 'cachyos-snapper-support' package already installed!
+winboat-package-installed = Winboat packages already installed!
 
 # Application Browser page
 advanced-btn = advanced
@@ -56,6 +57,7 @@ dnsserver-title = Change DNS server
 show-kwinw-debug-title = Show kwin(Wayland) debug window
 install-gaming-title = Install Gaming packages
 install-snapper-title = Install Snapper support
+install-winboat-title = Install Winboat
 
 # Main Page (buttons)
 button-about-tooltip = About

--- a/i18n/en/cachyos_hello.ftl
+++ b/i18n/en/cachyos_hello.ftl
@@ -35,6 +35,7 @@ dns-server-changed = DNS server was successfully changed!
 dns-server-failed = Failed to set DNS server!
 dns-server-reset = DNS server has been reset!
 dns-server-reset-failed = Failed to reset DNS server!
+winboat-install-failed = Failed to install Winboat!
 
 # Tweaks page (tweaks)
 tweak-enabled-title = {$tweak} enabled

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,5 +1,5 @@
 use crate::ui::{Action, DialogMessage, MessageType, RunCmdCallback};
-use crate::{fl, kwin_dbus, utils, systemd_units, PacmanWrapper};
+use crate::{fl, kwin_dbus, systemd_units, utils, PacmanWrapper};
 
 use std::path::Path;
 
@@ -266,7 +266,8 @@ pub fn install_winboat(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage
     const DOCKER_SERVICE: &str = "docker.service";
     let docker_enabled = systemd_units::check_system_units(DOCKER_SERVICE);
     if utils::is_alpm_pkg_installed("docker") && !docker_enabled {
-        let (cmd, run_as_root) = utils::get_tweak_toggle_cmd("service", DOCKER_SERVICE, docker_enabled);
+        let (cmd, run_as_root) =
+            utils::get_tweak_toggle_cmd("service", DOCKER_SERVICE, docker_enabled);
         let status_code = utils::run_cmd(cmd, run_as_root).unwrap();
         if !status_code.success() {
             dialog_tx

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -259,7 +259,7 @@ pub fn install_winboat(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage
         &ALPM_PACKAGE_NAMES,
         fl!("winboat-package-installed"),
         Action::InstallWinboat,
-        dialog_tx,
+        dialog_tx.clone(),
     );
 
     // Enable docker.service after installation
@@ -267,8 +267,17 @@ pub fn install_winboat(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage
     let docker_enabled = systemd_units::check_system_units(DOCKER_SERVICE);
     if utils::is_alpm_pkg_installed("docker") && !docker_enabled {
         let (cmd, run_as_root) = utils::get_tweak_toggle_cmd("service", DOCKER_SERVICE, docker_enabled);
-        utils::run_cmd(cmd, run_as_root);
-        
+        let status_code = utils::run_cmd(cmd, run_as_root).unwrap();
+        if !status_code.success() {
+            dialog_tx
+                .send(DialogMessage {
+                    msg: fl!("winboat-install-failed"),
+                    msg_type: MessageType::Error,
+                    action: Action::InstallWinboat,
+                })
+                .expect("Couldn't send data to channel");
+        }
+
         // refresh units cache
         systemd_units::refresh_system_cache();
     }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -266,6 +266,10 @@ pub fn install_winboat(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage
     const DOCKER_SERVICE: &str = "docker.service";
     let docker_enabled = systemd_units::check_system_units(DOCKER_SERVICE);
     if utils::is_alpm_pkg_installed("docker") && !docker_enabled {
-        let _ = utils::run_cmd("systemctl enable --now --force docker.service".into(), true);
+        let (cmd, run_as_root) = utils::get_tweak_toggle_cmd("service", DOCKER_SERVICE, docker_enabled);
+        utils::run_cmd(cmd, run_as_root);
+        
+        // refresh units cache
+        systemd_units::refresh_system_cache();
     }
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,5 +1,5 @@
 use crate::ui::{Action, DialogMessage, MessageType, RunCmdCallback};
-use crate::{fl, kwin_dbus, utils, PacmanWrapper};
+use crate::{fl, kwin_dbus, utils, systemd_units, PacmanWrapper};
 
 use std::path::Path;
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -251,3 +251,19 @@ pub fn install_snapper(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage
         dialog_tx,
     );
 }
+
+pub fn install_winboat(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage>) {
+    const ALPM_PACKAGE_NAMES: [&str; 3] = ["winboat", "docker", "docker-compose"];
+    install_needed_packages(
+        callback,
+        &ALPM_PACKAGE_NAMES,
+        fl!("winboat-package-installed"),
+        Action::InstallWinboat,
+        dialog_tx,
+    );
+
+    // Enable docker.service after installation
+    if utils::is_alpm_pkg_installed("docker") {
+        let _ = utils::run_cmd("systemctl enable --now --force docker.service".into(), true);
+    }
+}

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -263,7 +263,9 @@ pub fn install_winboat(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage
     );
 
     // Enable docker.service after installation
-    if utils::is_alpm_pkg_installed("docker") {
+    const DOCKER_SERVICE: &str = "docker.service";
+    let docker_enabled = systemd_units::check_system_units(DOCKER_SERVICE);
+    if utils::is_alpm_pkg_installed("docker") && !docker_enabled {
         let _ = utils::run_cmd("systemctl enable --now --force docker.service".into(), true);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,6 +76,8 @@ pub enum FixAction {
     InstallSnapper,
     /// Show the `KWin` Wayland debug console (if running)
     ShowKwinDebug,
+    /// Install Winboat for Windows applications
+    InstallWinboat,
 }
 
 #[derive(Args, Debug)]

--- a/src/cli_handler.rs
+++ b/src/cli_handler.rs
@@ -59,6 +59,10 @@ pub fn handle_fix_command(action: FixAction) -> Result<()> {
             println!("{}", "Attempting to launch KWin debug console...".bold());
             actions::launch_kwin_debug_window();
         },
+        FixAction::InstallWinboat => {
+            println!("{}", "Installing Winboat...".bold());
+            actions::install_winboat(crate::cli::run_command, tx);
+        },
     }
 
     rx.attach(None, move |msg| {

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -208,10 +208,10 @@ fn create_apps_section() -> Option<gtk::Box> {
     topbox.pack_end(&box_collection, true, true, 0);
 
     topbox.set_hexpand(true);
-    if !box_collection.children().is_empty() {
-        Some(topbox)
-    } else {
+    if box_collection.children().is_empty() {
         None
+    } else {
+        Some(topbox)
     }
 }
 

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -45,6 +45,7 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
 
     let install_gaming_btn = create_gtk_button!("install-gaming-title");
     let install_snapper_btn = create_gtk_button!("install-snapper-title");
+    let install_winboat_btn = create_gtk_button!("install-winboat-title");
 
     // Create context channel.
     let (dialog_tx, dialog_rx) = glib::MainContext::channel(glib::Priority::default());
@@ -53,6 +54,7 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
     let dialog_tx_clone = dialog_tx.clone();
     let dialog_tx_gaming = dialog_tx.clone();
     let dialog_tx_snapper = dialog_tx.clone();
+    let dialog_tx_winboat = dialog_tx.clone();
     removelock_btn.connect_clicked(move |_| {
         let dialog_tx_clone = dialog_tx_clone.clone();
         std::thread::spawn(move || {
@@ -95,18 +97,27 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
             actions::install_snapper(crate::gui::run_command, dialog_tx_snapper);
         });
     });
+    install_winboat_btn.connect_clicked(move |_| {
+        // Spawn child process in separate thread.
+        let dialog_tx_winboat = dialog_tx_winboat.clone();
+        std::thread::spawn(move || {
+            actions::install_winboat(crate::gui::run_command, dialog_tx_winboat);
+        });
+    });
 
     // Setup receiver.
     let removelock_btn_clone = removelock_btn.clone();
     let remove_orphans_btn_clone = remove_orphans_btn.clone();
     let install_gaming_btn_clone = install_gaming_btn.clone();
     let install_snapper_btn_clone = install_snapper_btn.clone();
+    let install_winboat_btn_clone = install_winboat_btn.clone();
     dialog_rx.attach(None, move |msg| {
         let widget_obj = match msg.action {
             Action::RemoveLock => &removelock_btn_clone,
             Action::RemoveOrphans => &remove_orphans_btn_clone,
             Action::InstallGaming => &install_gaming_btn_clone,
             Action::InstallSnapper => &install_snapper_btn_clone,
+            Action::InstallWinboat => &install_winboat_btn_clone,
             _ => panic!("Unexpected action!!"),
         };
         let widget_window =
@@ -129,6 +140,7 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
         button_box_t.pack_end(&install_snapper_btn, true, true, 2);
     }
     button_box_t.pack_end(&install_gaming_btn, true, true, 2);
+    button_box_t.pack_end(&install_winboat_btn, true, true, 2);
 
     if Path::new("/usr/bin/nmcli").exists() {
         let dnsserver_btn = create_gtk_button!("dnsserver-title");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -31,6 +31,7 @@ pub enum Action {
     SetDnsServer,
     InstallGaming,
     InstallSnapper,
+    InstallWinboat,
 }
 
 pub trait UI {


### PR DESCRIPTION
This adds a button to install winboat.

Winboat is a really create application to use windows programs easily on linux. Winboat plans to also integreate GPU acceleration, which then would make programs like photoshop, after effects and co viable to be used inside this VM.

Winboat uses a windows docker container.

<img width="1222" height="887" alt="image" src="https://github.com/user-attachments/assets/ca418428-dcf4-40eb-9d83-6378ae7f941c" />
