### PR TITLE
feat: add keyboard navigation support for accessibility

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -9,7 +9,7 @@ use gtk::prelude::*;
 
 use gtk::gdk_pixbuf::Pixbuf;
 use gtk::glib::GString;
-use gtk::{glib, Builder, HeaderBar, Window};
+use gtk::{gdk, glib, Builder, HeaderBar, Window};
 use tracing::{debug, error};
 use unic_langid::LanguageIdentifier;
 
@@ -61,6 +61,26 @@ impl HelloWindow {
             let icon_path = format!("{RESPREFIX}/data/img/{name}.png");
             let image: gtk::Image = builder.object(name.as_str()).unwrap();
             image.set_from_resource(Some(&icon_path));
+
+            // Enable keyboard activation (Enter/Space) for social EventBoxes
+            btn.connect_key_press_event(|widget, event| {
+                let keyval = event.keyval();
+                if keyval == gdk::keys::constants::Return
+                    || keyval == gdk::keys::constants::KP_Enter
+                    || keyval == gdk::keys::constants::space
+                {
+                    let name = widget.widget_name();
+                    let hello_window =
+                        unsafe { crate::G_HELLO_WINDOW.as_ref().unwrap() };
+                    let preferences = hello_window.get_preferences("urls");
+                    if let Some(uri) = preferences[name.as_str()].as_str() {
+                        hello_window.open_uri(uri);
+                    }
+                    glib::Propagation::Stop
+                } else {
+                    glib::Propagation::Proceed
+                }
+            });
         }
 
         let homepage_grid: gtk::Grid = builder.object("homepage").unwrap();
@@ -164,6 +184,15 @@ impl HelloWindow {
 
         // Show the UI
         main_window.show();
+
+        // Set initial focus on a meaningful interactive widget
+        if installer::is_iso(&preferences) {
+            let install: gtk::Button = builder.object("install").unwrap();
+            install.grab_focus();
+        } else {
+            let readme: gtk::Button = builder.object("readme").unwrap();
+            readme.grab_focus();
+        }
 
         // setup pages content
         let hello_window = HelloWindow { window: main_window, builder, preferences };

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,9 +1,12 @@
 use crate::config::{APP_ID, VERSION};
 use crate::{check_regular_file, installer, pages, utils, RESPREFIX};
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
+use std::rc::Rc;
+use std::time::Duration;
 
 use gtk::prelude::*;
 
@@ -70,8 +73,7 @@ impl HelloWindow {
                     || keyval == gdk::keys::constants::space
                 {
                     let name = widget.widget_name();
-                    let hello_window =
-                        unsafe { crate::G_HELLO_WINDOW.as_ref().unwrap() };
+                    let hello_window = unsafe { crate::G_HELLO_WINDOW.as_ref().unwrap() };
                     let preferences = hello_window.get_preferences("urls");
                     if let Some(uri) = preferences[name.as_str()].as_str() {
                         hello_window.open_uri(uri);
@@ -193,6 +195,31 @@ impl HelloWindow {
             let readme: gtk::Button = builder.object("readme").unwrap();
             readme.grab_focus();
         }
+
+        // Briefly dim focused widget on keyboard Tab for navigation feedback
+        let prev_dimmed: Rc<RefCell<Option<gtk::Widget>>> = Rc::new(RefCell::new(None));
+        let prev = prev_dimmed.clone();
+        let window = main_window.clone();
+        main_window.connect_key_press_event(move |_, event| {
+            let keyval = event.keyval();
+            if keyval == gdk::keys::constants::Tab || keyval == gdk::keys::constants::ISO_Left_Tab {
+                let window = window.clone();
+                let prev = prev.clone();
+                glib::idle_add_local_once(move || {
+                    if let Some(widget) = prev.borrow_mut().take() {
+                        widget.set_opacity(1.0);
+                    }
+                    if let Some(focused) = window.focused_widget() {
+                        focused.set_opacity(0.5);
+                        *prev.borrow_mut() = Some(focused.clone());
+                        glib::timeout_add_local_once(Duration::from_millis(180), move || {
+                            focused.set_opacity(1.0);
+                        });
+                    }
+                });
+            }
+            glib::Propagation::Proceed
+        });
 
         // setup pages content
         let hello_window = HelloWindow { window: main_window, builder, preferences };

--- a/ui/cachyos-hello.glade
+++ b/ui/cachyos-hello.glade
@@ -280,7 +280,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                 <child>
                   <object class="GtkComboBoxText" id="languages">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
+                    <property name="can-focus">False</property>
                     <items>
                       <item id="en">English</item>
                       <!-- Keep en first -->

--- a/ui/cachyos-hello.glade
+++ b/ui/cachyos-hello.glade
@@ -69,8 +69,7 @@ along with cachyos-welcome.  If not, see <http://www.gnu.org/licenses/>.
             <child>
               <object class="GtkLabel" id="welcometitle">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="has-focus">True</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Welcome to CachyOS!</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
@@ -148,7 +147,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                 <property name="label" translatable="yes">Read me</property>
                 <property name="name">readme</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
                 <signal name="clicked" handler="on_btn_clicked" swapped="no"/>
               </object>
@@ -162,7 +161,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                 <property name="label" translatable="yes">Release info</property>
                 <property name="name">release</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
                 <property name="always-show-image">True</property>
                 <signal name="clicked" handler="on_btn_clicked" swapped="no"/>
@@ -177,7 +176,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                 <property name="label" translatable="yes">Wiki</property>
                 <property name="name">wiki</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
                 <property name="tooltip-text" translatable="yes">Web resource</property>
                 <property name="image-position">right</property>
@@ -194,7 +193,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                 <property name="label" translatable="yes">Get involved</property>
                 <property name="name">involved</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
                 <signal name="clicked" handler="on_btn_clicked" swapped="no"/>
               </object>
@@ -208,7 +207,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                 <property name="label" translatable="yes">Forums</property>
                 <property name="name">forum</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
                 <property name="tooltip-text" translatable="yes">Web resource</property>
                 <property name="image-position">right</property>
@@ -225,7 +224,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                 <property name="label" translatable="yes">Software</property>
                 <property name="name">software</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
                 <property name="tooltip-text" translatable="yes">Web resource</property>
                 <property name="image-position">right</property>
@@ -242,7 +241,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                 <property name="label" translatable="yes">Development</property>
                 <property name="name">development</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
                 <property name="tooltip-text" translatable="yes">Web resource</property>
                 <property name="image-position">right</property>
@@ -259,7 +258,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                 <property name="label" translatable="yes">Donate</property>
                 <property name="name">donate</property>
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
                 <property name="tooltip-text" translatable="yes">Web resource</property>
                 <property name="image-position">right</property>
@@ -281,7 +280,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                 <child>
                   <object class="GtkComboBoxText" id="languages">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <items>
                       <item id="en">English</item>
                       <!-- Keep en first -->
@@ -371,7 +370,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
               <object class="GtkButton" id="install">
                 <property name="label" translatable="yes">Launch installer</property>
                 <property name="name">install</property>
-                <property name="can-focus">False</property>
+                <property name="can-focus">True</property>
                 <property name="receives-default">True</property>
                 <signal name="clicked" handler="on_action_clicked" swapped="no"/>
               </object>
@@ -390,7 +389,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                   <object class="GtkButton" id="tweaksBrowser">
                     <property name="label" translatable="yes">Apps/Tweaks</property>
                     <property name="name">tweaksBrowser</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
                     <property name="tooltip-text" translatable="yes">Apps/Tweaks</property>
                     <property name="margin-left">15</property>
@@ -407,7 +406,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                   <object class="GtkButton" id="appBrowser">
                     <property name="label" translatable="yes">Install Apps</property>
                     <property name="name">appBrowser</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <property name="receives-default">True</property>
                     <property name="tooltip-text" translatable="yes">Common application selection</property>
                     <property name="margin-left">15</property>
@@ -437,7 +436,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                   <object class="GtkEventBox">
                     <property name="name">discord</property>
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <signal name="button-press-event" handler="on_link1_clicked" swapped="no"/>
                     <child>
                       <object class="GtkImage" id="discord">
@@ -457,7 +456,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                   <object class="GtkEventBox">
                     <property name="name">reddit</property>
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can-focus">True</property>
                     <signal name="button-press-event" handler="on_link1_clicked" swapped="no"/>
                     <child>
                       <object class="GtkImage" id="reddit">
@@ -520,7 +519,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
           <object class="GtkButton" id="about">
             <property name="name">about</property>
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can-focus">True</property>
             <property name="receives-default">True</property>
             <property name="tooltip-text" translatable="yes">About</property>
             <property name="image">abouticon</property>

--- a/ui/style.css
+++ b/ui/style.css
@@ -22,6 +22,32 @@ window {
     border-radius: 5px 5px 5px 5px;
 }
 
+/* Focus indicators for keyboard navigation */
+button:focus {
+    outline: 2px solid @theme_selected_bg_color;
+    outline-offset: 2px;
+}
+
+combobox button:focus {
+    outline: 2px solid @theme_selected_bg_color;
+    outline-offset: 2px;
+}
+
+switch:focus {
+    outline: 2px solid @theme_selected_bg_color;
+    outline-offset: 2px;
+}
+
+checkbutton:focus {
+    outline: 2px solid @theme_selected_bg_color;
+    outline-offset: 2px;
+}
+
+eventbox:focus {
+    outline: 2px solid @theme_selected_bg_color;
+    outline-offset: 2px;
+}
+
 .aboutdialog {
     border-radius: 7px;
 }

--- a/ui/style.css
+++ b/ui/style.css
@@ -22,32 +22,6 @@ window {
     border-radius: 5px 5px 5px 5px;
 }
 
-/* Focus indicators for keyboard navigation */
-button:focus {
-    outline: 2px solid @theme_selected_bg_color;
-    outline-offset: 2px;
-}
-
-combobox button:focus {
-    outline: 2px solid @theme_selected_bg_color;
-    outline-offset: 2px;
-}
-
-switch:focus {
-    outline: 2px solid @theme_selected_bg_color;
-    outline-offset: 2px;
-}
-
-checkbutton:focus {
-    outline: 2px solid @theme_selected_bg_color;
-    outline-offset: 2px;
-}
-
-eventbox:focus {
-    outline: 2px solid @theme_selected_bg_color;
-    outline-offset: 2px;
-}
-
 .aboutdialog {
     border-radius: 7px;
 }


### PR DESCRIPTION
Enable Tab-based keyboard navigation throughout the welcome screen by setting can-focus=True on all interactive widgets (buttons, social links, language selector, about button). Add visible focus indicators via CSS outline using theme colors, and handle Enter/Space key activation on social EventBox icons (discord, reddit) which lack built-in keyboard support. Set initial focus to the install button on ISO or readme button on installed systems. Remove incorrect initial focus from the non-interactive welcome title label.

Fixes: https://github.com/CachyOS/CachyOS-Welcome/issues/161