### PR TITLE
remove: drop Snapper support from welcome app

### DIFF
--- a/i18n/af/cachyos_hello.ftl
+++ b/i18n/af/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = Pacman db-slot bestaan nie!
 orphans-not-found = Geen onteiende pakkette gevind nie!
 package-not-installed = Pakket '{$package_name}' is nie geïnstalleer nie!
 gaming-package-installed = Speletjiepakkette reeds geïnstalleer!
-snapper-package-installed = 'cachyos-snapper-support' reeds geïnstalleer!
 
 # Application Browser page
 advanced-btn = Gevorderde
@@ -48,7 +47,6 @@ rankmirrors-title = Rangskik spieëls
 dnsserver-title = Verander DNS-bediener
 show-kwinw-debug-title = Wys kwin(Wayland) ontfoutvenster
 install-gaming-title = Installeer Speletjiepakkette
-install-snapper-title = Installeer Snapper-ondersteuning
 
 # Main Page (buttons)
 button-about-tooltip = Oor

--- a/i18n/ar/cachyos_hello.ftl
+++ b/i18n/ar/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = قفل قاعدة بيانات pacman غير موجود!
 orphans-not-found = لم يُعثر على حزم يتيمة!
 package-not-installed = لم يتم تثبيت الحزمة '{$package_name}'!
 gaming-package-installed = حزم الألعاب مثبتة بالفعل!
-snapper-package-installed = حزمة 'cachyos-snapper-support' مثبتة بالفعل!
 
 # Application Browser page
 advanced-btn = متقدم
@@ -54,7 +53,6 @@ rankmirrors-title = رتب المرايا
 dnsserver-title = غيّر خادم DNS
 show-kwinw-debug-title = أظهر نافذة تصحيح kwin(Wayland)
 install-gaming-title = ثبّت حزم الألعاب
-install-snapper-title = ثبّت دعم Snapper
 
 # Main Page (buttons)
 button-about-tooltip = عن

--- a/i18n/bg/cachyos_hello.ftl
+++ b/i18n/bg/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = Заключването на Pacman базата данни
 orphans-not-found = Не са намерени осиротели пакети!
 package-not-installed = Пакетът '{$package_name}' не е инсталиран!
 gaming-package-installed = Пакетите за игри вече са инсталирани!
-snapper-package-installed = Пакетът 'cachyos-snapper-support' вече е инсталиран!
 
 # Application Browser page
 advanced-btn = разширени
@@ -54,7 +53,6 @@ rankmirrors-title = Класиране на огледалните сървър�
 dnsserver-title = Промяна на DNS сървъра
 show-kwinw-debug-title = Показване на прозореца за отстраняване на грешки на kwin(Wayland)
 install-gaming-title = Инсталиране на пакети за игри
-install-snapper-title = Инсталиране на поддръжка за Snapper
 
 # Main Page (buttons)
 button-about-tooltip = Относно

--- a/i18n/by/cachyos_hello.ftl
+++ b/i18n/by/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = Pacman БД не заблакаваны!
 orphans-not-found = Пакеты-сіроты не знойдзены!
 package-not-installed = Пакет '{$package_name}' не быў усталяваны!
 gaming-package-installed = Гульнявыя пакеты ўжо ўстаноўлены!
-snapper-package-installed = 'cachyos-snapper-support' пакет ужо ўсталяваны!
 
 # Application Browser page
 advanced-btn = дадатковыя
@@ -48,7 +47,6 @@ rankmirrors-title = Ранг люстэркаў
 dnsserver-title = Змяніць DNS-сервер
 show-kwinw-debug-title = Паказаць акно адладкі kwin (Wayland).
 install-gaming-title = Усталюйце Гульнявыя пакеты
-install-snapper-title = Усталюйце падтрымку Snapper
 
 # Main Page (buttons)
 button-about-tooltip = Аб праграме

--- a/i18n/ca/cachyos_hello.ftl
+++ b/i18n/ca/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = El blocatge de la base de dades del Pacman no existeix!
 orphans-not-found = No s'ha trobat cap paquet orfe!
 package-not-installed = El paquet {$package_name} no s'ha instal·lat!
 gaming-package-installed = Els paquets de joc ja estan instal·lats!
-snapper-package-installed = El paquet cachyos-snapper-support ja està instal·lat!
 
 # Application Browser page
 advanced-btn = Avançat
@@ -48,7 +47,6 @@ rankmirrors-title = Classifica les rèpliques
 dnsserver-title = Canvia el servidor de DNS
 show-kwinw-debug-title = Mostra la finestra de depuració del kwin (Wayland)
 install-gaming-title = Instal·la paquets de jocs
-install-snapper-title = Instal·la suport per a instantànies
 
 # Main Page (buttons)
 button-about-tooltip = Quant a

--- a/i18n/cs/cachyos_hello.ftl
+++ b/i18n/cs/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = Zámek Pacman db neexistuje!
 orphans-not-found = Nenašli se žádní sirotci balíčků!
 package-not-installed = Balíček '{$package_name}' nebyl nainstalovaný!
 gaming-package-installed = Herní balíčky jsou už nainstalované!
-snapper-package-installed = Balíček 'cachyos-snapper-support' je už nainstalovaný!
 
 # Stránka s prohlížečem aplikací
 advanced-btn = pokročilé
@@ -48,7 +47,6 @@ rankmirrors-title = Přehodnotit zrcadla
 dnsserver-title = Změnit DNS server
 show-kwinw-debug-title = Zobrazit kwin(Wayland) debug okno
 install-gaming-title = Instalovat herní balíčky
-install-snapper-title = Instalovat podporu Snapper
 
 # Hlavní stránka (tlačítka)
 button-about-tooltip = O programu

--- a/i18n/en/cachyos_hello.ftl
+++ b/i18n/en/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = Pacman db lock does not exist!
 orphans-not-found = No orphan packages found!
 package-not-installed = Package '{$package_name}' has not been installed!
 gaming-package-installed = Gaming packages already installed!
-snapper-package-installed = 'cachyos-snapper-support' package already installed!
 winboat-package-installed = Winboat packages already installed!
 
 # Application Browser page
@@ -57,7 +56,6 @@ rankmirrors-title = Rank mirrors
 dnsserver-title = Change DNS server
 show-kwinw-debug-title = Show kwin(Wayland) debug window
 install-gaming-title = Install Gaming packages
-install-snapper-title = Install Snapper support
 install-winboat-title = Install Winboat
 
 # Main Page (buttons)

--- a/i18n/es/cachyos_hello.ftl
+++ b/i18n/es/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = La base de datos de Pacman no esta bloqueada!
 orphans-not-found = No se encontraron paquetes huérfanos!
 package-not-installed = El paquete '{$package_name}' no ha sido instalado!
 gaming-package-installed = Los paquetes de Gaming ya han sido instalados!
-snapper-package-installed = 'cachyos-snapper-support' ya ha sido instalado!
 
 # Application Browser page
 advanced-btn = avanzado
@@ -48,7 +47,6 @@ rankmirrors-title = Evaluar mirrors
 dnsserver-title = Cambiar servidor DNS
 show-kwinw-debug-title = Mostrar la ventana debug de kwin(Wayland)
 install-gaming-title = Instalar paquetes de Gaming
-install-snapper-title = Instalar soporte de Snapper
 
 # Main Page (buttons)
 button-about-tooltip = Sobre

--- a/i18n/et/cachyos_hello.ftl
+++ b/i18n/et/cachyos_hello.ftl
@@ -10,7 +10,6 @@ lock-doesnt-exist = Pacmani andmebaasi lukku ei eksisteeri!
 orphans-not-found = Ühtegi orbpaketti ei leitud!
 package-not-installed = Paketti '{$package_name}' pole paigaldatud!
 gaming-package-installed = Mängupaketid on juba paigaldatud!
-snapper-package-installed = Pakett 'cachyos-snapper-support' on juba paigaldatud!
 
 # Application Browser page
 advanced-btn = edasijõudnutele
@@ -53,7 +52,6 @@ rankmirrors-title = Järjesta peeglid
 dnsserver-title = Muuda DNS-serverit
 show-kwinw-debug-title = Näita kwin(Wayland) silumisakent
 install-gaming-title = Paigalda mängupaketid
-install-snapper-title = Paigalda Snapperi tugi
 
 # Main Page (buttons)
 button-about-tooltip = Teave

--- a/i18n/fr/cachyos_hello.ftl
+++ b/i18n/fr/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = Le verrou de la base de données Pacman n'existe pas !
 orphans-not-found = Aucun paquet orphelin trouvé !
 package-not-installed = Le paquet '{$package_name}' n'a pas été installé !
 gaming-package-installed = Paquets de Gaming déjà installés !
-snapper-package-installed = Le paquet 'cachyos-snapper-support' est déjà installé !
 
 # Application Browser page
 advanced-btn = Avancé
@@ -48,7 +47,6 @@ rankmirrors-title = Classer les miroirs
 dnsserver-title = Changer le serveur DNS
 show-kwinw-debug-title = Montrer la fenêtre de débuggage de kwin(Wayland)
 install-gaming-title = Installer les paquets de Gaming
-install-snapper-title = Installer le support pour Snapper
 
 # Main Page (buttons)
 button-about-tooltip = À propos

--- a/i18n/he/cachyos_hello.ftl
+++ b/i18n/he/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = מסד הנתונים של Pacman אינו נעול!
 orphans-not-found = לא נמצאו חבילות שאינן משויכות!
 package-not-installed = החבילה ‚{$package_name}’ לא הותקנה!
 gaming-package-installed = החבילות למשחקים כבר מותקנות!
-snapper-package-installed = החבילה ‚cachyos-snapper-support’ כבר מותקנת!
 
 # Application Browser page
 advanced-btn = מתקדם
@@ -56,7 +55,6 @@ rankmirrors-title = השוואת אתרי מראה
 dnsserver-title = שינוי שרת DNS
 show-kwinw-debug-title = הצגת חלון ניפוי השגיאות של kwin(Wayland)
 install-gaming-title = התקנת חבילות למשחקים
-install-snapper-title = התקנת תמיכה ב־Snapper
 
 # Main Page (buttons)
 button-about-tooltip = על אודות

--- a/i18n/hu/cachyos_hello.ftl
+++ b/i18n/hu/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = A Pacman adatbázis zárolása nem létezik!
 orphans-not-found = Nem találhatók árva csomagok!
 package-not-installed = A(z) „{$package_name}” csomag nem lett telepítve!
 gaming-package-installed = A játékcsomagok már telepítve vannak!
-snapper-package-installed = A „cachyos-snapper-support” csomag már telepítve van!
 
 # Application Browser page
 advanced-btn = speciális
@@ -55,7 +54,6 @@ rankmirrors-title = Tükrök rangsorolása
 dnsserver-title = DNS szerver megváltoztatása
 show-kwinw-debug-title = KWin (Wayland) hibakereső ablak megjelenítése
 install-gaming-title = Játékcsomagok telepítése
-install-snapper-title = Snapper támogatás telepítése
 
 # Main Page (buttons)
 button-about-tooltip = Névjegy

--- a/i18n/ko-KR/cachyos_hello.ftl
+++ b/i18n/ko-KR/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = Pacman DB 잠금 파일이 존재하지 않습니다!
 orphans-not-found = 고아 패키지를 찾을 수 없습니다!
 package-not-installed = '{$package_name}' 패키지가 설치되지 않았습니다!
 gaming-package-installed = 게임 패키지가 이미 설치되어 있습니다!
-snapper-package-installed = 'cachyos-snapper-support' 패키지가 이미 설치되어 있습니다!
 
 # Application Browser page
 advanced-btn = 고급
@@ -54,7 +53,6 @@ rankmirrors-title = 미러 순위 지정
 dnsserver-title = DNS 서버 변경
 show-kwinw-debug-title = KWin(Wayland) 디버그 창 표시
 install-gaming-title = 게임 패키지 설치
-install-snapper-title = Snapper 지원 설치
 
 # Main Page (buttons)
 button-about-tooltip = 정보

--- a/i18n/nb/cachyos_hello.ftl
+++ b/i18n/nb/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = Pacman db lås finnes ikke!
 orphans-not-found = Ingen foreldreløse pakker finnes!
 package-not-installed = '{$package_name}' pakken ble ikke installert!
 gaming-package-installed = Spillpakkene er allerede installert!
-snapper-package-installed = 'cachyos-snapper-support' pakken er allerede installert!
 
 # Application Browser page
 advanced-btn = avansert
@@ -55,7 +54,6 @@ rankmirrors-title = Ranger pakketjenere
 dnsserver-title = Endre DNS server
 show-kwinw-debug-title = Vis kwin(Wayland) feilsøkings vindu
 install-gaming-title = Installer Spill pakker
-install-snapper-title = Installer Snapper støtte
 
 # Main Page (buttons)
 button-about-tooltip = Om

--- a/i18n/nl/cachyos_hello.ftl
+++ b/i18n/nl/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = De Pacman db-vergrendeling is niet aanwezig!
 orphans-not-found = Er zijn geen onteigende pakketten aangetroffen.
 package-not-installed = ‘{$package_name}’ is niet geïnstalleerd!
 gaming-package-installed = De gamingpakketten zijn al geïnstalleerd.
-snapper-package-installed = ‘cachyos-snapper-support’ is al geïnstalleerd.
 
 # Application Browser page
 advanced-btn = Geavanceerd
@@ -48,7 +47,6 @@ rankmirrors-title = Spiegelservers klassificeren
 dnsserver-title = Dns-server wĳzigen
 show-kwinw-debug-title = Kwin(Wayland)-foutopsporingsvenster openen
 install-gaming-title = Gamingpakketten installeren
-install-snapper-title = Snapper-ondersteuning inschakelen
 
 # Main Page (buttons)
 button-about-tooltip = Over

--- a/i18n/pl/cachyos_hello.ftl
+++ b/i18n/pl/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = Blokada bazy Pacmana nie istnieje!
 orphans-not-found = Nie znaleziono osieroconych pakietów!
 package-not-installed = Pakiet '{$package_name}' nie został zainstalowany!
 gaming-package-installed = Pakiety do gier są już zainstalowane!
-snapper-package-installed = Pakiet 'cachyos-snapper-support' jest już zainstalowany!
 
 # Application Browser page
 advanced-btn = zaawansowane
@@ -55,7 +54,6 @@ rankmirrors-title = Uszereguj serwery
 dnsserver-title = Zmień serwer DNS
 show-kwinw-debug-title = Pokaż okno deubowania kwin(Wayland)
 install-gaming-title = Zainstaluj pakiety do gier
-install-snapper-title = Zainstaluj wsparcie dla Snappera
 
 # Main Page (buttons)
 button-about-tooltip = O programie

--- a/i18n/pt-BR/cachyos_hello.ftl
+++ b/i18n/pt-BR/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = O arquivo db.lock do Pacman não existe!
 orphans-not-found = Não foram encontrados pacotes órfãos!
 package-not-installed = O pacote '{$package_name}' não foi instalado!
 gaming-package-installed = Os pacotes de jogos já estão instalados!
-snapper-package-installed = O pacote 'cachyos-snapper-support' já foi instalado!
 
 # Application Browser page
 advanced-btn = Avançado
@@ -48,7 +47,6 @@ rankmirrors-title = Atualizar Espelhos
 dnsserver-title = Trocar Servidor DNS
 show-kwinw-debug-title = Exibir a Janela de Debug do KWin(Wayland)
 install-gaming-title = Instalar Pacotes de Jogos
-install-snapper-title = Instalar Suporte a Snapper
 
 # Main Page (buttons)
 button-about-tooltip = Sobre

--- a/i18n/ru/cachyos_hello.ftl
+++ b/i18n/ru/cachyos_hello.ftl
@@ -10,7 +10,6 @@ removed-db-lock = Блокировка БД Pacman была снята!
 lock-doesnt-exist = БД pacman не заблокирована!
 package-not-installed = Пакет '{$package_name}' не был установлен!
 gaming-package-installed = Игровые пакеты уже установлены!
-snapper-package-installed = Пакет 'cachyos-snapper-support' уже установлен!
 
 # Application Browser page
 advanced-btn = дополнительные
@@ -48,7 +47,6 @@ rankmirrors-title = Ранжировать зеркала
 dnsserver-title = Сменить DNS-сервер
 show-kwinw-debug-title = Показать окно отладки kwin(Wayland)
 install-gaming-title = Установить пакеты для игр
-install-snapper-title = Установить поддержку Snapper
 
 # Main Page (buttons)
 button-about-tooltip = О программе

--- a/i18n/sk/cachyos_hello.ftl
+++ b/i18n/sk/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = Zámok Pacman db neexistuje!
 orphans-not-found = Nenašli sa žiadne siroty balíčkov!
 package-not-installed = Balíček '{$package_name}' nebol nainštalovaný!
 gaming-package-installed = Herné balíčky sú už nainštalované!
-snapper-package-installed = Balíček 'cachyos-snapper-support' je už nainštalovaný!
 
 # Stránka s prehliadačom aplikácií
 advanced-btn = pokročilé
@@ -48,7 +47,6 @@ rankmirrors-title = Prehodnotiť zrkadlá
 dnsserver-title = Zmeniť DNS server
 show-kwinw-debug-title = Zobraziť kwin(Wayland) debug okno
 install-gaming-title = Inštalovať herné balíčky
-install-snapper-title = Inštalovať podporu Snapper
 
 # Hlavná stránka (tlačidlá)
 button-about-tooltip = O programe

--- a/i18n/sq/cachyos_hello.ftl
+++ b/i18n/sq/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = Bllokimi i databazës së Pacman nuk ekziston!
 orphans-not-found = Nuk u gjetën paketa të jetime (orphans)!
 package-not-installed = Paketa '{$package_name}' nuk është instaluar!
 gaming-package-installed = Paketat për lojëra janë të instaluara tashmë!
-snapper-package-installed = Paketa 'cachyos-snapper-support' është instaluar tashmë!
 
 # Application Browser page
 advanced-btn = të avancuara
@@ -54,7 +53,6 @@ rankmirrors-title = Rendit pasqyrat (mirrors)
 dnsserver-title = Ndrysho serverin DNS
 show-kwinw-debug-title = Shfaq dritaren debug të kwin (Wayland)
 install-gaming-title = Instalo paketat për lojëra
-install-snapper-title = Instalo përkrahje për Snapper
 
 # Main Page (buttons)
 button-about-tooltip = Rreth

--- a/i18n/sv/cachyos_hello.ftl
+++ b/i18n/sv/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = Databaslås för Pacman finns inte!
 orphans-not-found = Inga föräldralösa paket hittades!
 package-not-installed = Paketet '{$package_name}' har inte installerats!
 gaming-package-installed = Spelpaket redan installerade!
-snapper-package-installed = Paketet 'cachyos-snapper-support' är redan installerat!
 
 # Application Browser page
 advanced-btn = avancerat
@@ -48,7 +47,6 @@ rankmirrors-title = Ranka spegelservrar
 dnsserver-title = Byt DNS-server
 show-kwinw-debug-title = Visa kwin(Wayland) felsökningsfönster
 install-gaming-title = Installera spelpaket
-install-snapper-title = Installera stöd för Snapper
 
 # Main Page (buttons)
 button-about-tooltip = Om

--- a/i18n/tr/cachyos_hello.ftl
+++ b/i18n/tr/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = Pacman veritabanı kilidi bulunmamaktadır!
 orphans-not-found = Hiçbir artık (orphan) paket bulunamadı!
 package-not-installed = '{$package_name}' paketi kurulmamıştır!
 gaming-package-installed = Oyun paketleri halihazırda kurulu!
-snapper-package-installed = 'cachyos-snapper-support' paketi halihazırda kurulu!
 
 # Application Browser page
 advanced-btn = gelişmiş
@@ -55,7 +54,6 @@ rankmirrors-title = Yansıları hıza göre sırala
 dnsserver-title = DNS sunucusunu değiştir
 show-kwinw-debug-title = KWin (Wayland) hata ayıklama penceresini göster
 install-gaming-title = Oyun paketlerini kur
-install-snapper-title = Snapper desteği kur
 
 # Main Page (buttons)
 button-about-tooltip = Hakkında

--- a/i18n/uk/cachyos_hello.ftl
+++ b/i18n/uk/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = Блокування бази даних Pacman відсут
 orphans-not-found = Осиротілих пакетів не знайдено!
 package-not-installed = Пакет '{$package_name}' не встановлено!
 gaming-package-installed = Ігрові пакети вже встановлені!
-snapper-package-installed = Пакет «cachyos-snapper-support» уже встановлено!
 winboat-package-installed = Пакети Winboat вже встановлені!
 
 # Application Browser page
@@ -57,7 +56,6 @@ rankmirrors-title = Оптимізувати дзеркала
 dnsserver-title = Змінити DNS-сервер
 show-kwinw-debug-title = Показати вікно налагодження KWin (Wayland)
 install-gaming-title = Встановити ігрові пакети
-install-snapper-title = Встановити підтримку Snapper
 install-winboat-title = Встановити Winboat
 
 # Main Page (buttons)

--- a/i18n/vi/cachyos_hello.ftl
+++ b/i18n/vi/cachyos_hello.ftl
@@ -11,7 +11,6 @@ lock-doesnt-exist = Pacman db lock không tồn tại!
 orphans-not-found = Không có các gói dư thừa!
 package-not-installed = Gói '{$package_name}' chưa được cài đặt!
 gaming-package-installed = Các gói thiết kế cho chơi game (Gaming) đã được cài đặt!
-snapper-package-installed = Gói 'cachyos-snapper-support' đã được cài đặt!
 
 # Application Browser page
 advanced-btn = Nâng cao
@@ -55,7 +54,6 @@ rankmirrors-title = xếp hạng các mirror
 dnsserver-title = đổi DNS server
 show-kwinw-debug-title = hiển thị kwin(Wayland) để xem lỗi
 install-gaming-title = Cài các gói chơi game
-install-snapper-title = Cài Snapper support
 
 # Main Page (buttons)
 button-about-tooltip = Giới thiệu

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -242,16 +242,6 @@ pub fn install_gaming(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage>
     );
 }
 
-pub fn install_snapper(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage>) {
-    install_needed_packages(
-        callback,
-        &["cachyos-snapper-support"],
-        fl!("snapper-package-installed"),
-        Action::InstallSnapper,
-        dialog_tx,
-    );
-}
-
 pub fn install_winboat(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage>) {
     const ALPM_PACKAGE_NAMES: [&str; 3] = ["winboat", "docker", "docker-compose"];
     install_needed_packages(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,8 +72,6 @@ pub enum FixAction {
     RankMirrors,
     /// Install `CachyOS` gaming meta-packages
     InstallGaming,
-    /// Install Snapper support for BTRFS snapshots
-    InstallSnapper,
     /// Show the `KWin` Wayland debug console (if running)
     ShowKwinDebug,
     /// Install Winboat for Windows applications

--- a/src/cli_handler.rs
+++ b/src/cli_handler.rs
@@ -48,13 +48,6 @@ pub fn handle_fix_command(action: FixAction) -> Result<()> {
             println!("{}", "Installing CachyOS gaming packages...".bold());
             actions::install_gaming(crate::cli::run_command, tx);
         },
-        FixAction::InstallSnapper => {
-            if !utils::is_root_on_btrfs() {
-                anyhow::bail!("Snapper requires a BTRFS root filesystem.");
-            }
-            println!("{}", "Installing Snapper support...".bold());
-            actions::install_snapper(crate::cli::run_command, tx);
-        },
         FixAction::ShowKwinDebug => {
             println!("{}", "Attempting to launch KWin debug console...".bold());
             actions::launch_kwin_debug_window();

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -44,7 +44,6 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
     let rankmirrors_btn = create_gtk_button!("rankmirrors-title");
 
     let install_gaming_btn = create_gtk_button!("install-gaming-title");
-    let install_snapper_btn = create_gtk_button!("install-snapper-title");
     let install_winboat_btn = create_gtk_button!("install-winboat-title");
 
     // Create context channel.
@@ -53,7 +52,6 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
     // Connect signals.
     let dialog_tx_clone = dialog_tx.clone();
     let dialog_tx_gaming = dialog_tx.clone();
-    let dialog_tx_snapper = dialog_tx.clone();
     let dialog_tx_winboat = dialog_tx.clone();
     removelock_btn.connect_clicked(move |_| {
         let dialog_tx_clone = dialog_tx_clone.clone();
@@ -90,13 +88,6 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
             actions::install_gaming(crate::gui::run_command, dialog_tx_gaming);
         });
     });
-    install_snapper_btn.connect_clicked(move |_| {
-        // Spawn child process in separate thread.
-        let dialog_tx_snapper = dialog_tx_snapper.clone();
-        std::thread::spawn(move || {
-            actions::install_snapper(crate::gui::run_command, dialog_tx_snapper);
-        });
-    });
     install_winboat_btn.connect_clicked(move |_| {
         // Spawn child process in separate thread.
         let dialog_tx_winboat = dialog_tx_winboat.clone();
@@ -109,14 +100,12 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
     let removelock_btn_clone = removelock_btn.clone();
     let remove_orphans_btn_clone = remove_orphans_btn.clone();
     let install_gaming_btn_clone = install_gaming_btn.clone();
-    let install_snapper_btn_clone = install_snapper_btn.clone();
     let install_winboat_btn_clone = install_winboat_btn.clone();
     dialog_rx.attach(None, move |msg| {
         let widget_obj = match msg.action {
             Action::RemoveLock => &removelock_btn_clone,
             Action::RemoveOrphans => &remove_orphans_btn_clone,
             Action::InstallGaming => &install_gaming_btn_clone,
-            Action::InstallSnapper => &install_snapper_btn_clone,
             Action::InstallWinboat => &install_winboat_btn_clone,
             _ => panic!("Unexpected action!!"),
         };
@@ -136,9 +125,6 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
     button_box_s.pack_start(&clear_pkgcache_btn, true, true, 2);
     button_box_s.pack_end(&remove_orphans_btn, true, true, 2);
     button_box_t.pack_end(&rankmirrors_btn, true, true, 2);
-    if utils::is_root_on_btrfs() {
-        button_box_t.pack_end(&install_snapper_btn, true, true, 2);
-    }
     button_box_t.pack_end(&install_gaming_btn, true, true, 2);
     button_box_t.pack_end(&install_winboat_btn, true, true, 2);
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -30,7 +30,6 @@ pub enum Action {
     RemoveOrphans,
     SetDnsServer,
     InstallGaming,
-    InstallSnapper,
     InstallWinboat,
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,7 +6,7 @@ use std::{fs, slice, str};
 
 use gtk::prelude::*;
 
-use subprocess::{Exec, ExitStatus, Redirection};
+use subprocess::{Exec, ExitStatus};
 
 #[derive(Debug)]
 pub enum PacmanWrapper {
@@ -157,17 +157,6 @@ pub fn is_alpm_pkg_installed(package_name: &str) -> bool {
     let pacman = pacmanconf::Config::with_opts(None, Some("/etc/pacman.conf"), Some("/")).unwrap();
     let alpm = alpm_utils::alpm_with_conf(&pacman).unwrap();
     alpm.localdb().pkg(package_name.as_bytes()).is_ok()
-}
-
-pub fn is_root_on_btrfs() -> bool {
-    let root_fs = Exec::cmd("/sbin/findmnt")
-        .args(&["-ln", "-o", "FSTYPE", "/"])
-        .stdout(Redirection::Pipe)
-        .capture()
-        .unwrap()
-        .stdout_str();
-
-    root_fs == "btrfs\n"
 }
 
 pub fn get_tweak_toggle_cmd(


### PR DESCRIPTION
Snapper snapshot support has been successfully integrated directly into the CachyOS installer for GRUB and Limine bootloaders, making the post-install setup step in cachyos-welcome redundant. rEFInd-BTRFS integration is still pending upstream but is not currently supported anyway.

Remove the `install_snapper` action, the `InstallSnapper` CLI subcommand and its BTRFS root check, the corresponding GUI button and signal handler, the `is_root_on_btrfs` utility function, and the `InstallSnapper` UI action variant.