### PR TITLE
Fix: Connectivity check incorrectly returns true even when ping fails

### DIFF
--- a/src/installer.rs
+++ b/src/installer.rs
@@ -105,16 +105,16 @@ fn connectivity_check(ui: &GUI, message: String) -> bool {
 
     // If HTTP check fails, try ping fallback to reliable DNS servers
     let targets = [
-        "2001:4860:4860::8888",
-        "2606:4700:4700::1111",
-        "2620:fe::fe",
         "8.8.8.8",
         "1.1.1.1",
         "9.9.9.9",
+        "2001:4860:4860::8888",
+        "2606:4700:4700::1111",
+        "2620:fe::fe",
     ];
     for target in targets {
         let ping_result = Exec::cmd("/sbin/ping").args(&["-c", "1", "-W", "3", target]).join();
-        if ping_result.map(subprocess::ExitStatus::success).is_ok() {
+        if ping_result.map(|status| status.success()).unwrap_or(false) {
             info!("Connectivity confirmed via ping to {target}");
             return true;
         }

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -114,7 +114,7 @@ fn connectivity_check(ui: &GUI, message: String) -> bool {
     ];
     for target in targets {
         let ping_result = Exec::cmd("/sbin/ping").args(&["-c", "1", "-W", "3", target]).join();
-        if ping_result.map(|status| status.success()).unwrap_or(false) {
+        if ping_result.map(subprocess::ExitStatus::success).unwrap_or(false) {
             info!("Connectivity confirmed via ping to {target}");
             return true;
         }


### PR DESCRIPTION
### What
Fixed a logic error where `ping_result.is_ok()` was used to determine network connectivity. This only checks if the ping process was successfully started, not whether the ping itself succeeded.

### Why
In the current implementation, as long as the `/sbin/ping` command exists on the system, the function returns true regardless of whether the target host is actually reachable. This leads to false positives in connectivity checks.

### How
Changed the logic to verify the process exit status. Now it checks if the command both executed successfully and returned a success exit code (status 0) using:
```rs
ping_result.map(subprocess::ExitStatus::success).unwrap_or(false)
```

### Note on target order
I also moved the IPv4 addresses to the top of the list. In environments with misconfigured or partial IPv6 support, pinging IPv6 addresses first can cause significant delays (up to 9 seconds in this case) due to timeouts. Prioritizing IPv4 ensures a faster connectivity check for the majority of users.