### PR TITLE
Swedish l10n: Improve translations and add missing strings

### DIFF
--- a/i18n/sv/cachyos_hello.ftl
+++ b/i18n/sv/cachyos_hello.ftl
@@ -5,23 +5,24 @@ about-dialog-comments = Välkomstskärm för CachyOS
 # Tweaks page
 tweaks = Tweaks
 fixes = Verktyg
-applications = Applikationer
-removed-db-lock = Databaslås för Pacman togs bort!
-lock-doesnt-exist = Databaslås för Pacman finns inte!
+applications = Program
+removed-db-lock = Pacman-databaslås togs bort!
+lock-doesnt-exist = Pacman-databaslås finns inte!
 orphans-not-found = Inga föräldralösa paket hittades!
 package-not-installed = Paketet '{$package_name}' har inte installerats!
 gaming-package-installed = Spelpaket redan installerade!
+winboat-package-installed = Winboat-paket redan installerade!
 
 # Application Browser page
 advanced-btn = avancerat
 reset-btn = återställ
 update-system-app-btn = UPPDATERA SYSTEMET
-application-column = Applikation
+application-column = Program
 description-column = Beskrivning
 install-remove-column = Installera/Ta bort
-advanced-btn-tooltip = Växla till en utökad paketmarkering
+advanced-btn-tooltip = Växla till utökad paketmarkering
 reset-btn-tooltip = Återställ dina aktuella markeringar...
-update-system-app-btn-tooltip = Tillämpa dina aktuella markeringar till systemet
+update-system-app-btn-tooltip = Tillämpa dina aktuella markeringar på systemet
 
 # Dns Connections page
 dns-settings = DNS-inställningar
@@ -31,22 +32,31 @@ apply = Tillämpa
 reset = Återställ
 dns-server-changed = DNS-servern ändrades!
 dns-server-failed = Misslyckades med att ställa in DNS-server!
-dns-server-reset = DNS-server har återställts!
+dns-server-reset = DNS-servern har återställts!
 dns-server-reset-failed = Misslyckades med att återställa DNS-servern!
+winboat-install-failed = Misslyckades med att installera Winboat!
 
 # Tweaks page (tweaks)
 tweak-enabled-title = {$tweak} aktiverad
+tweak-psd-tooltip = Använd RAM-minne för webbläsarprofiler (snabbare, mindre diskslitage)
+tweak-oomd-tooltip = Döda processer proaktivt vid lågt minne för att förhindra hängningar
+tweak-bpftune-tooltip = Ställ in systemnätverket automatiskt
+tweak-bluetooth-tooltip = Aktivera stöd för trådlösa Bluetooth-enheter (möss, ljud, etc.)
+tweak-ananicycpp-tooltip = Justera processprioriteter automatiskt för bättre systemrespons
+tweak-cachyupdate-tooltip = Uppdateringsnotifierare i systemfältet
 
 # Tweaks page (fixes)
 remove-lock-title = Ta bort databaslås
 reinstall-title = Installera om alla paket
+reset-keyrings-title = Återställ nyckelringar
 update-system-title = Systemuppdatering
 remove-orphans-title = Ta bort föräldralösa
 clear-pkgcache-title = Töm paketcache
-rankmirrors-title = Ranka spegelservrar
+rankmirrors-title = Ranka speglar
 dnsserver-title = Byt DNS-server
 show-kwinw-debug-title = Visa kwin(Wayland) felsökningsfönster
 install-gaming-title = Installera spelpaket
+install-winboat-title = Installera Winboat
 
 # Main Page (buttons)
 button-about-tooltip = Om
@@ -73,12 +83,12 @@ calamares-install-type = Calamares installationstyp
 
 # Main Page (body)
 offline-error = Det går inte att starta online-installationen! Ingen internetanslutning
-unsupported-hw-warning = Om du försöker installera på maskinvara som inte stöds av den aktuella ISO:n kommer din installation inte att vara berättigad till support
+unsupported-hw-warning = Du försöker installera på maskinvara som inte stöds av den aktuella ISO:n, din installation kommer inte att vara berättigad till support
 desktop-on-handheld-error = Du försöker installera Desktop-utgåvan på en handhållen enhet. Använd Handheld-utgåvan för korrekt stöd på denna maskinvara
 outdated-version-warning = Du använder en äldre version av CachyOS ISO, överväg att använda den senaste versionen för installationer
 testing-iso-warning = Du använder en test-ISO, test-ISO:er anses inte vara stabila och klara för användning
-tweaksbrowser-label = Appar/Tweaks
-appbrowser-label = Installera appar
+tweaksbrowser-label = Program/Tweaks
+appbrowser-label = Installera program
 launch-start-label = Starta vid uppstart
 welcome-title = Välkommen till CachyOS!
 welcome-body =


### PR DESCRIPTION
This PR improves the Swedish translation by:

- Adding missing translations for winboat-related strings
- Adding missing tooltip translations  
- Changing 'Applikationer' to 'Program' for better consistency
- Fixing compound words: 'Pacman-databaslås'
- Improving 'spegelservrar' to 'speglar' (more concise)
- Minor wording improvements throughout

Following Swedish Unix/Linux conventions as requested.