### PR TITLE
Add --overwrite '/*' to the reinstall packages button. 

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -165,7 +165,7 @@ pub fn clear_pkgcache(callback: RunCmdCallback) {
 }
 
 pub fn reinstall_packages(callback: RunCmdCallback) {
-    let _ = utils::run_cmd_terminal(callback, String::from("pacman -S $(pacman -Qnq)"), true);
+    let _ = utils::run_cmd_terminal(callback, String::from("pacman -S --overwrite='/*' $(pacman -Qnq)"), true);
 }
 
 pub fn remove_orphans(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage>) {


### PR DESCRIPTION
Add --overwrite flag so this will actually act when the system is in an inconsistant state