### PR TITLE
feat(dns): add DHCP automatic indicator and reset-to-DHCP

### DIFF
--- a/i18n/en/cachyos_hello.ftl
+++ b/i18n/en/cachyos_hello.ftl
@@ -45,6 +45,7 @@ latency-testing = testing...
 latency-timeout = timeout
 latency-no-result = no server responded
 custom-dns = Custom
+dhcp-automatic = DHCP (automatic)
 custom-dns-ipv4 = IPv4 addresses (comma-separated):
 custom-dns-ipv6 = IPv6 addresses (comma-separated):
 custom-dns-dot-hostname = DoT hostname (optional):

--- a/src/pages/dns.rs
+++ b/src/pages/dns.rs
@@ -42,8 +42,8 @@ fn selection_index_for_connection(conn_name: &str) -> usize {
         return dns::G_DNS_SERVERS.len();
     }
 
-    // No DNS configured, fallback to Cloudflare
-    dns::G_DNS_SERVERS.get_index("Cloudflare").unwrap()
+    // No DNS configured — using DHCP (automatic)
+    usize::MAX
 }
 
 /// Returns whether the server at `index` supports `DoT`.
@@ -112,6 +112,8 @@ fn create_connections_section() -> gtk::Box {
         }
         let custom_label = fl!("custom-dns");
         store.set(&store.append(), &[(0, &custom_label)]);
+        let dhcp_label = fl!("dhcp-automatic");
+        store.set(&store.append(), &[(0, &dhcp_label)]);
         utils::create_combo_with_model(&store)
     };
 
@@ -215,9 +217,17 @@ fn create_connections_section() -> gtk::Box {
             combo_conn.set_active_iter(Some(&iter));
 
             let selected_dns_index = selection_index_for_connection(&active_conn_name);
-            combo_servers.set_active(Some(selected_dns_index as u32));
+            let dhcp_index = dns::G_DNS_SERVERS.len() + 1;
+            let combo_index = if selected_dns_index == usize::MAX { dhcp_index } else { selected_dns_index };
+            combo_servers.set_active(Some(combo_index as u32));
 
-            if selected_dns_index == dns::G_DNS_SERVERS.len() {
+            if selected_dns_index == usize::MAX {
+                // DHCP (automatic) — disable protocol checkboxes
+                dot_check.set_sensitive(false);
+                dot_check.set_active(false);
+                doh_check.set_sensitive(false);
+                doh_check.set_active(false);
+            } else if selected_dns_index == dns::G_DNS_SERVERS.len() {
                 // Custom DNS — pre-fill entries with current values
                 if actions::is_blocky_active() {
                     // Custom DoH — fill from blocky config;
@@ -274,14 +284,21 @@ fn create_connections_section() -> gtk::Box {
     combo_servers.connect_changed(move |combo| {
         if let Some(idx) = combo.active() {
             let is_custom = idx as usize == dns::G_DNS_SERVERS.len();
+            let is_dhcp = idx as usize == dns::G_DNS_SERVERS.len() + 1;
             if is_custom {
                 custom_box_vis.foreach(gtk::prelude::WidgetExt::show_all);
                 custom_box_vis.show();
             } else {
                 custom_box_vis.hide();
             }
-            best_btn_vis.set_visible(!is_custom);
-            if is_custom {
+            best_btn_vis.set_visible(!is_custom && !is_dhcp);
+            if is_dhcp {
+                dot_check_clone.set_sensitive(false);
+                dot_check_clone.set_active(false);
+                doh_check_clone.set_sensitive(false);
+                doh_check_clone.set_active(false);
+                info_label_clone.set_visible(false);
+            } else if is_custom {
                 dot_check_clone.set_sensitive(true);
                 doh_check_clone.set_sensitive(true);
                 doh_check_clone.set_active(false);
@@ -437,6 +454,19 @@ fn create_connections_section() -> gtk::Box {
         let conn_name: String = combo_conn_clone.active_text().map(Into::into).unwrap_or_default();
         let is_custom =
             combo_serv_clone.active().is_some_and(|idx| idx as usize == dns::G_DNS_SERVERS.len());
+        let is_dhcp = combo_serv_clone.active().is_some_and(|idx| {
+            idx as usize == dns::G_DNS_SERVERS.len() + 1
+        });
+
+        // DHCP (automatic) selected — reset to defaults
+        if is_dhcp {
+            let dialog_tx_clone = dialog_tx_clone.clone();
+            std::thread::spawn(move || {
+                actions::reset_dns_server(&conn_name, dialog_tx_clone);
+            });
+            return;
+        }
+
         let enable_dot = dot_check_clone3.is_active();
         let enable_doh = doh_check_clone3.is_active();
 
@@ -528,9 +558,17 @@ fn create_connections_section() -> gtk::Box {
     });
     let dialog_tx_clone = dialog_tx.clone();
     let combo_conn_clone = combo_conn.clone();
+    let combo_serv_reset = combo_servers.clone();
+    let dot_check_reset = dot_check.clone();
+    let doh_check_reset = doh_check.clone();
     reset_btn.connect_clicked(move |_| {
         let dialog_tx_clone = dialog_tx_clone.clone();
         let conn_name: String = combo_conn_clone.active_text().map(Into::into).unwrap_or_default();
+        // Set combo to DHCP (automatic)
+        let dhcp_index = (dns::G_DNS_SERVERS.len() + 1) as u32;
+        combo_serv_reset.set_active(Some(dhcp_index));
+        dot_check_reset.set_active(false);
+        doh_check_reset.set_active(false);
         std::thread::spawn(move || {
             actions::reset_dns_server(&conn_name, dialog_tx_clone);
         });


### PR DESCRIPTION
Follow-up to #200 (DoH support) as discussed.

## What changed

**DHCP (automatic) indicator**

- Added a "DHCP (automatic)" entry at the bottom of the DNS server dropdown
- When no DNS servers are manually configured, "DHCP (automatic)" is shown as selected9; making it clear to the user that DHCP-provided DNS is in use
- Previously, the dropdown would misleadingly show "Cloudflare" as a fallback even when no custom DNS was set

**Reset behavior**

- Selecting "DHCP (automatic)" and clicking Apply resets DNS to automatic (same behavior as the Reset button)
- Pressing Reset now jumps the dropdown to "DHCP (automatic)" and unchecks DoT/DoH checkboxes for visual consistency
- DoT/DoH checkboxes and latency test buttons are disabled when DHCP is selected (no server to configure)

**i18n**

- Added `dhcp-automatic` string to en locale

<img width="794" height="600" alt="image" src="https://github.com/user-attachments/assets/446737fb-5238-404d-85e2-b6a63ebc889b" />


## Testing

- Start with no DNS configured → dropdown shows "DHCP (automatic)" ✓
- Set Cloudflare DoH → dropdown shows "Cloudflare" with DoH checked ✓
- Click Reset → dropdown jumps to "DHCP (automatic)", checkboxes unchecked ✓
- Select "DHCP (automatic)" + Apply → DNS reset to DHCP ✓
- Switch connections → dropdown updates correctly ✓