### PR TITLE
Add StartupWMClass to cachyos-hello .desktop to improve window matching

### DIFF
--- a/cachyos-hello.desktop
+++ b/cachyos-hello.desktop
@@ -6,6 +6,7 @@ StartupNotify=false
 Name=CachyOS Hello
 Exec=/usr/bin/cachyos-hello
 Icon=org.cachyos.hello
+StartupWMClass=org.cachyos.hello
 Comment=A tool providing access to documentation and support for new CachyOS users.
 Comment[bg]=Инструмент, предоставящ достъп до документация и поддръжка за нови потребители на CachyOS.
 Comment[da]=En app med adgang til dokumentation og support for nye CachyOS brugere.


### PR DESCRIPTION
On GNOME desktops in particular (see attached), it is failing to match the app ID to the corresponding .desktop file, resulting in generic icon/name. This harmlessly provides a hint, improving compatibility
<img width="120" height="145" alt="image" src="https://github.com/user-attachments/assets/6573e3b3-82a1-4ae3-b35d-df0ee7bf35e8" />
