### PR TITLE
fix: Single instance - present existing window on reactivation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,13 @@ fn main() {
         );
 
         application.connect_activate(|application| {
+            // If a window already exists, raise the window to the front and give it focus
+            unsafe {
+                if let Some(window) = G_HELLO_WINDOW.as_ref() {
+                    window.window.present();
+                    return;
+                }
+            }
             build_ui(application);
         });
 


### PR DESCRIPTION
When a second instance of the application was launched, GTK correctly routed the activate signal to the already-running instance, but connect_activate unconditionally called build_ui, creating a second window. Additionally, build_ui calls systemd_units::refresh_cache() which blocks the GTK main thread on D-Bus I/O, causing the first instance to hang.

Check if G_HELLO_WINDOW is already set in connect_activate and call window.present() to raise the existing window instead of rebuilding the UI.

Fixes #211 