### PR TITLE
fix: replace deprecated glib::MainContext::channel with async_channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +285,7 @@ dependencies = [
  "alpm",
  "alpm-utils",
  "anyhow",
+ "async-channel",
  "chwd",
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { version = "1.50", features = ["macros", "sync", "rt-multi-thread"] }
 zbus = { version = "5", features = ["tokio"], default-features = false }
 zbus_systemd = { version = "0.26000.0", features = ["systemd1"], default-features = false }
 clap = { features = ["derive"], version = "4" }
+async-channel = "2"
 colored = "3"
 tempfile = "3.27"
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::time::Duration;
 use std::{env, io, thread};
 
-use gtk::glib::Sender;
+use async_channel::Sender;
 use subprocess::Exec;
 use tracing::error;
 
@@ -134,7 +134,7 @@ pub fn change_dns_server(
     })();
     if result.is_ok() {
         dialog_tx
-            .send(DialogMessage {
+            .send_blocking(DialogMessage {
                 msg: fl!("dns-server-changed"),
                 msg_type: MessageType::Info,
                 action: Action::SetDnsServer,
@@ -142,7 +142,7 @@ pub fn change_dns_server(
             .expect("Couldn't send data to channel");
     } else {
         dialog_tx
-            .send(DialogMessage {
+            .send_blocking(DialogMessage {
                 msg: fl!("dns-server-failed"),
                 msg_type: MessageType::Error,
                 action: Action::SetDnsServer,
@@ -168,7 +168,7 @@ pub fn reset_dns_server(conn_name: &str, dialog_tx: Sender<DialogMessage>) {
     })();
     if result.is_ok() {
         dialog_tx
-            .send(DialogMessage {
+            .send_blocking(DialogMessage {
                 msg: fl!("dns-server-reset"),
                 msg_type: MessageType::Info,
                 action: Action::SetDnsServer,
@@ -176,7 +176,7 @@ pub fn reset_dns_server(conn_name: &str, dialog_tx: Sender<DialogMessage>) {
             .expect("Couldn't send data to channel");
     } else {
         dialog_tx
-            .send(DialogMessage {
+            .send_blocking(DialogMessage {
                 msg: fl!("dns-server-reset-failed"),
                 msg_type: MessageType::Error,
                 action: Action::SetDnsServer,
@@ -228,7 +228,7 @@ pub fn change_dns_server_doh(
     })();
     if write_result.is_err() {
         dialog_tx
-            .send(DialogMessage {
+            .send_blocking(DialogMessage {
                 msg: fl!("dns-server-failed"),
                 msg_type: MessageType::Error,
                 action: Action::SetDnsServer,
@@ -255,7 +255,7 @@ pub fn change_dns_server_doh(
 
     if result.is_ok() {
         dialog_tx
-            .send(DialogMessage {
+            .send_blocking(DialogMessage {
                 msg: fl!("dns-server-changed"),
                 msg_type: MessageType::Info,
                 action: Action::SetDnsServer,
@@ -263,7 +263,7 @@ pub fn change_dns_server_doh(
             .expect("Couldn't send data to channel");
     } else {
         dialog_tx
-            .send(DialogMessage {
+            .send_blocking(DialogMessage {
                 msg: fl!("dns-server-failed"),
                 msg_type: MessageType::Error,
                 action: Action::SetDnsServer,
@@ -288,7 +288,7 @@ pub fn remove_dblock(dialog_tx: Sender<DialogMessage>) {
         let _ = utils::pkexec_cmd(&["rm", "/var/lib/pacman/db.lck"]);
         if !Path::new("/var/lib/pacman/db.lck").exists() {
             dialog_tx
-                .send(DialogMessage {
+                .send_blocking(DialogMessage {
                     msg: fl!("removed-db-lock"),
                     msg_type: MessageType::Info,
                     action: Action::RemoveLock,
@@ -297,7 +297,7 @@ pub fn remove_dblock(dialog_tx: Sender<DialogMessage>) {
         }
     } else {
         dialog_tx
-            .send(DialogMessage {
+            .send_blocking(DialogMessage {
                 msg: fl!("lock-doesnt-exist"),
                 msg_type: MessageType::Info,
                 action: Action::RemoveLock,
@@ -337,7 +337,7 @@ pub fn remove_orphans(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage>
     orphan_pkgs = orphan_pkgs.replace('\n', " ");
     if orphan_pkgs.is_empty() {
         dialog_tx
-            .send(DialogMessage {
+            .send_blocking(DialogMessage {
                 msg: fl!("orphans-not-found"),
                 msg_type: MessageType::Info,
                 action: Action::RemoveOrphans,
@@ -375,7 +375,7 @@ pub fn install_needed_packages(
     // skip if installed already
     if packages_to_install.is_empty() {
         dialog_tx
-            .send(DialogMessage {
+            .send_blocking(DialogMessage {
                 msg: dialog_msg,
                 msg_type: MessageType::Info,
                 action: dialog_action,
@@ -421,7 +421,7 @@ pub fn install_winboat(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage
         let result = systemd_units::systemd_enable(&[DOCKER_TARGET], Scope::System, false);
         if result.is_err() {
             dialog_tx
-                .send(DialogMessage {
+                .send_blocking(DialogMessage {
                     msg: fl!("winboat-install-failed"),
                     msg_type: MessageType::Error,
                     action: Action::InstallWinboat,
@@ -441,7 +441,7 @@ pub fn install_winboat(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage
                 .map_or(true, |s| !s.success());
             if failed {
                 dialog_tx
-                    .send(DialogMessage {
+                    .send_blocking(DialogMessage {
                         msg: fl!("winboat-install-failed"),
                         msg_type: MessageType::Error,
                         action: Action::InstallWinboat,

--- a/src/cli_handler.rs
+++ b/src/cli_handler.rs
@@ -82,7 +82,22 @@ pub fn handle_dns_command(action: DnsAction) -> Result<()> {
             if doh {
                 // DoH mode via blocky
                 let doh_url = dns::get_doh_url(server_name);
-                if doh_url.is_none() {
+                if let Some(url) = doh_url {
+                    println!(
+                        "Setting DNS for '{}' to '{}' (DoH enabled via blocky)...",
+                        connection.cyan(),
+                        server_name.cyan(),
+                    );
+                    actions::change_dns_server_doh(
+                        crate::cli::run_command,
+                        &connection,
+                        url,
+                        server_addr.0,
+                        server_addr.1,
+                        server_addr.2,
+                        tx,
+                    );
+                } else {
                     println!(
                         "{}: DNS over HTTPS is not supported by '{}'.",
                         "Warning".yellow(),
@@ -96,21 +111,6 @@ pub fn handle_dns_command(action: DnsAction) -> Result<()> {
                         server_addr.1,
                         false,
                         dot_hostname,
-                        tx,
-                    );
-                } else {
-                    println!(
-                        "Setting DNS for '{}' to '{}' (DoH enabled via blocky)...",
-                        connection.cyan(),
-                        server_name.cyan(),
-                    );
-                    actions::change_dns_server_doh(
-                        crate::cli::run_command,
-                        &connection,
-                        doh_url.unwrap(),
-                        server_addr.0,
-                        server_addr.1,
-                        server_addr.2,
                         tx,
                     );
                 }

--- a/src/cli_handler.rs
+++ b/src/cli_handler.rs
@@ -7,10 +7,10 @@ use crate::{actions, dns, systemd_units, utils};
 
 use anyhow::Result;
 use colored::Colorize;
-use gtk::glib;
+use async_channel;
 
 pub fn handle_fix_command(action: FixAction) -> Result<()> {
-    let (tx, rx) = glib::MainContext::channel(glib::Priority::default());
+    let (tx, rx) = async_channel::unbounded();
 
     match action {
         FixAction::UpdateSystem => {
@@ -57,11 +57,10 @@ pub fn handle_fix_command(action: FixAction) -> Result<()> {
         },
     }
 
-    rx.attach(None, move |msg| {
+    while let Ok(msg) = rx.try_recv() {
         let ui_comp = crate::cli::CLI::new();
         ui_comp.show_message(msg.msg_type, &msg.msg, msg.msg_type.to_string());
-        glib::ControlFlow::Continue
-    });
+    }
     Ok(())
 }
 
@@ -74,7 +73,7 @@ pub fn handle_tweak_command(action: TweakAction) -> Result<()> {
 }
 
 pub fn handle_dns_command(action: DnsAction) -> Result<()> {
-    let (tx, rx) = glib::MainContext::channel(glib::Priority::default());
+    let (tx, rx) = async_channel::unbounded();
 
     match action {
         DnsAction::Set { connection, server, dot, doh } => {
@@ -251,11 +250,10 @@ pub fn handle_dns_command(action: DnsAction) -> Result<()> {
             }
         },
     }
-    rx.attach(None, move |msg| {
+    while let Ok(msg) = rx.try_recv() {
         let ui_comp = crate::cli::CLI::new();
         ui_comp.show_message(msg.msg_type, &msg.msg, msg.msg_type.to_string());
-        glib::ControlFlow::Continue
-    });
+    }
     Ok(())
 }
 

--- a/src/cli_handler.rs
+++ b/src/cli_handler.rs
@@ -7,7 +7,6 @@ use crate::{actions, dns, systemd_units, utils};
 
 use anyhow::Result;
 use colored::Colorize;
-use async_channel;
 
 pub fn handle_fix_command(action: FixAction) -> Result<()> {
     let (tx, rx) = async_channel::unbounded();

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -9,8 +9,8 @@ pub fn setup_logger() -> WorkerGuard {
     let env_filter = EnvFilter::try_from_default_env();
 
     // create subscriber env filter
-    let subscriber_env_filter =
-        env_filter.unwrap_or_else(|_| EnvFilter::new("debug,i18n_embed=warn,which=warn,zbus::proxy=warn"));
+    let subscriber_env_filter = env_filter
+        .unwrap_or_else(|_| EnvFilter::new("debug,i18n_embed=warn,which=warn,zbus::proxy=warn"));
 
     // create stdout layer
     let stdout_log = tracing_subscriber::fmt::layer().compact().with_writer(std::io::stdout);

--- a/src/pages/dns.rs
+++ b/src/pages/dns.rs
@@ -3,7 +3,6 @@ use crate::{actions, create_gtk_button, dns, fl, utils};
 
 use gtk::prelude::*;
 
-use async_channel;
 use gtk::{glib, Builder};
 
 /// Returns true if `s` contains only valid DNS address characters (hex digits, dots, colons,

--- a/src/pages/dns.rs
+++ b/src/pages/dns.rs
@@ -3,6 +3,7 @@ use crate::{actions, create_gtk_button, dns, fl, utils};
 
 use gtk::prelude::*;
 
+use async_channel;
 use gtk::{glib, Builder};
 
 /// Returns true if `s` contains only valid DNS address characters (hex digits, dots, colons,
@@ -346,7 +347,7 @@ fn create_connections_section() -> gtk::Box {
     let custom_ipv4_entry_latency = custom_ipv4_entry.clone();
     let latency_label_clone = latency_label.clone();
     let latency_btn_clone = latency_btn.clone();
-    let (latency_tx, latency_rx) = glib::MainContext::channel(glib::Priority::default());
+    let (latency_tx, latency_rx) = async_channel::unbounded();
     latency_btn.connect_clicked(move |_| {
         let is_custom =
             combo_serv_latency.active().is_some_and(|idx| idx as usize == dns::G_DNS_SERVERS.len());
@@ -367,26 +368,26 @@ fn create_connections_section() -> gtk::Box {
         latency_label_clone.set_text(&fl!("latency-testing"));
         std::thread::spawn(move || {
             let result = dns::measure_latency(&ipv4);
-            let _ = tx.send(result);
+            let _ = tx.send_blocking(result);
         });
     });
     let latency_label_rx = latency_label.clone();
     let latency_btn_rx = latency_btn.clone();
-    latency_rx.attach(None, move |result| {
-        match result {
-            Some(ms) => latency_label_rx.set_markup(&format!("<b>{ms} ms</b>")),
-            None => latency_label_rx.set_text(&fl!("latency-timeout")),
+    glib::MainContext::default().spawn_local(async move {
+        while let Ok(result) = latency_rx.recv().await {
+            match result {
+                Some(ms) => latency_label_rx.set_markup(&format!("<b>{ms} ms</b>")),
+                None => latency_label_rx.set_text(&fl!("latency-timeout")),
+            }
+            latency_btn_rx.set_sensitive(true);
         }
-        latency_btn_rx.set_sensitive(true);
-        glib::ControlFlow::Continue
     });
 
     // Best server button handler
     let combo_serv_best = combo_servers.clone();
     let best_btn_clone = best_btn.clone();
     let latency_label_best = latency_label.clone();
-    let (best_tx, best_rx) =
-        glib::MainContext::channel::<Option<(&'static str, u128)>>(glib::Priority::default());
+    let (best_tx, best_rx) = async_channel::unbounded::<Option<(&'static str, u128)>>();
     best_btn.connect_clicked(move |_| {
         let tx = best_tx.clone();
         best_btn_clone.set_sensitive(false);
@@ -397,31 +398,32 @@ fn create_connections_section() -> gtk::Box {
                 .iter()
                 .find(|(n, ms)| ms.is_some() && !dns::is_filtering_server(n))
                 .map(|&(name, ms)| (name, ms.unwrap()));
-            let _ = tx.send(best);
+            let _ = tx.send_blocking(best);
         });
     });
     let combo_serv_best_rx = combo_serv_best.clone();
     let best_btn_rx = best_btn.clone();
     let latency_label_best_rx = latency_label.clone();
-    best_rx.attach(None, move |result| {
-        match result {
-            Some((name, ms)) => {
-                let model = combo_serv_best_rx.model().unwrap();
-                if let Some(iter) = utils::find_iter_in_model(&model, name) {
-                    combo_serv_best_rx.set_active_iter(Some(&iter));
-                }
-                latency_label_best_rx.set_markup(&format!("<b>{ms} ms</b>"));
-            },
-            None => {
-                latency_label_best_rx.set_text(&fl!("latency-no-result"));
-            },
+    glib::MainContext::default().spawn_local(async move {
+        while let Ok(result) = best_rx.recv().await {
+            match result {
+                Some((name, ms)) => {
+                    let model = combo_serv_best_rx.model().unwrap();
+                    if let Some(iter) = utils::find_iter_in_model(&model, name) {
+                        combo_serv_best_rx.set_active_iter(Some(&iter));
+                    }
+                    latency_label_best_rx.set_markup(&format!("<b>{ms} ms</b>"));
+                },
+                None => {
+                    latency_label_best_rx.set_text(&fl!("latency-no-result"));
+                },
+            }
+            best_btn_rx.set_sensitive(true);
         }
-        best_btn_rx.set_sensitive(true);
-        glib::ControlFlow::Continue
     });
 
     // Create context channel.
-    let (dialog_tx, dialog_rx) = glib::MainContext::channel(glib::Priority::default());
+    let (dialog_tx, dialog_rx) = async_channel::unbounded();
 
     // Connect signals.
     let dialog_tx_clone = dialog_tx.clone();
@@ -447,7 +449,7 @@ fn create_connections_section() -> gtk::Box {
             let ipv4_valid = ipv4.is_empty() || is_valid_dns_input(&ipv4);
             let ipv6_valid = ipv6.is_empty() || is_valid_dns_input(&ipv6);
             if (ipv4.is_empty() && ipv6.is_empty()) || !ipv4_valid || !ipv6_valid {
-                let _ = dialog_tx_clone.send(DialogMessage {
+                let _ = dialog_tx_clone.try_send(DialogMessage {
                     msg: fl!("custom-dns-invalid"),
                     msg_type: MessageType::Error,
                     action: Action::SetDnsServer,
@@ -455,7 +457,7 @@ fn create_connections_section() -> gtk::Box {
                 return;
             }
             if !hostname.is_empty() && !dns::is_valid_dot_hostname(&hostname) {
-                let _ = dialog_tx_clone.send(DialogMessage {
+                let _ = dialog_tx_clone.try_send(DialogMessage {
                     msg: fl!("custom-dns-invalid-hostname"),
                     msg_type: MessageType::Error,
                     action: Action::SetDnsServer,
@@ -479,7 +481,7 @@ fn create_connections_section() -> gtk::Box {
             let (doh_url, bootstrap_ipv4, bootstrap_ipv6, bootstrap_dot) = if is_custom {
                 let custom_doh_url: String = custom_doh_entry_apply.text().trim().to_string();
                 if custom_doh_url.is_empty() || !custom_doh_url.starts_with("https://") {
-                    let _ = dialog_tx_clone.send(DialogMessage {
+                    let _ = dialog_tx_clone.try_send(DialogMessage {
                         msg: fl!("custom-dns-doh-url-required"),
                         msg_type: MessageType::Error,
                         action: Action::SetDnsServer,
@@ -538,14 +540,15 @@ fn create_connections_section() -> gtk::Box {
 
     // Setup receiver
     let apply_btn_clone = apply_btn.clone();
-    dialog_rx.attach(None, move |msg| {
-        let widget_obj = &apply_btn_clone;
-        let widget_window =
-            utils::get_window_from_widget(widget_obj).expect("Failed to retrieve window");
-        let ui_comp = crate::gui::GUI::new(widget_window);
+    glib::MainContext::default().spawn_local(async move {
+        while let Ok(msg) = dialog_rx.recv().await {
+            let widget_obj = &apply_btn_clone;
+            let widget_window =
+                utils::get_window_from_widget(widget_obj).expect("Failed to retrieve window");
+            let ui_comp = crate::gui::GUI::new(widget_window);
 
-        ui_comp.show_message(msg.msg_type, &msg.msg, msg.msg_type.to_string());
-        glib::ControlFlow::Continue
+            ui_comp.show_message(msg.msg_type, &msg.msg, msg.msg_type.to_string());
+        }
     });
 
     topbox.pack_start(&label, true, false, 1);

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -229,8 +229,8 @@ pub fn create_tweaks_page(builder: &Builder) {
     let child_name = "tweaksBrowserpage";
     options_section_box.set_widget_name(&format!("{child_name}_options"));
     fixes_section_box.set_widget_name(&format!("{child_name}_fixes"));
-    if apps_section_box_opt.is_some() {
-        apps_section_box_opt.as_ref().unwrap().set_widget_name(&format!("{child_name}_apps"));
+    if let Some(apps_section_box) = apps_section_box_opt.as_ref() {
+        apps_section_box.set_widget_name(&format!("{child_name}_apps"));
     }
 
     let grid = gtk::Grid::new();

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -11,6 +11,7 @@ use std::str;
 use gtk::prelude::*;
 
 use gtk::{glib, Builder};
+use async_channel;
 use subprocess::Exec;
 use tracing::debug;
 use which::which;
@@ -47,7 +48,7 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
     let install_winboat_btn = create_gtk_button!("install-winboat-title");
 
     // Create context channel.
-    let (dialog_tx, dialog_rx) = glib::MainContext::channel(glib::Priority::default());
+    let (dialog_tx, dialog_rx) = async_channel::unbounded();
 
     // Connect signals.
     let dialog_tx_clone = dialog_tx.clone();
@@ -101,20 +102,21 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
     let remove_orphans_btn_clone = remove_orphans_btn.clone();
     let install_gaming_btn_clone = install_gaming_btn.clone();
     let install_winboat_btn_clone = install_winboat_btn.clone();
-    dialog_rx.attach(None, move |msg| {
-        let widget_obj = match msg.action {
-            Action::RemoveLock => &removelock_btn_clone,
-            Action::RemoveOrphans => &remove_orphans_btn_clone,
-            Action::InstallGaming => &install_gaming_btn_clone,
-            Action::InstallWinboat => &install_winboat_btn_clone,
-            _ => panic!("Unexpected action!!"),
-        };
-        let widget_window =
-            utils::get_window_from_widget(widget_obj).expect("Failed to retrieve window");
-        let ui_comp = crate::gui::GUI::new(widget_window);
+    glib::MainContext::default().spawn_local(async move {
+        while let Ok(msg) = dialog_rx.recv().await {
+            let widget_obj = match msg.action {
+                Action::RemoveLock => &removelock_btn_clone,
+                Action::RemoveOrphans => &remove_orphans_btn_clone,
+                Action::InstallGaming => &install_gaming_btn_clone,
+                Action::InstallWinboat => &install_winboat_btn_clone,
+                _ => panic!("Unexpected action!!"),
+            };
+            let widget_window =
+                utils::get_window_from_widget(widget_obj).expect("Failed to retrieve window");
+            let ui_comp = crate::gui::GUI::new(widget_window);
 
-        ui_comp.show_message(msg.msg_type, &msg.msg, msg.msg_type.to_string());
-        glib::ControlFlow::Continue
+            ui_comp.show_message(msg.msg_type, &msg.msg, msg.msg_type.to_string());
+        }
     });
 
     topbox.pack_start(&label, true, false, 1);

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -11,7 +11,6 @@ use std::str;
 use gtk::prelude::*;
 
 use gtk::{glib, Builder};
-use async_channel;
 use subprocess::Exec;
 use tracing::debug;
 use which::which;

--- a/src/pages/tweaks.rs
+++ b/src/pages/tweaks.rs
@@ -8,6 +8,7 @@ use std::str;
 use gtk::prelude::*;
 use subprocess::Exec;
 
+use async_channel;
 use glib::translate::FromGlib;
 use gtk::glib;
 
@@ -92,7 +93,7 @@ fn toggle_service(
         systemd_units::check_system_units(action_data)
     };
     // Create context channel.
-    let (tx, rx) = glib::MainContext::channel(glib::Priority::default());
+    let (tx, rx) = async_channel::unbounded();
 
     let dialog_text = fl!("package-not-installed", package_name = alpm_package_name);
 
@@ -110,7 +111,7 @@ fn toggle_service(
                 );
             }
             if !utils::is_alpm_pkg_installed(&alpm_package_name) {
-                tx.send(false).expect("Couldn't send data to channel");
+                tx.send_blocking(false).expect("Couldn't send data to channel");
                 return;
             }
         }
@@ -138,14 +139,15 @@ fn toggle_service(
         }
     });
 
-    rx.attach(None, move |msg| {
-        if !msg {
-            callback(msg);
+    glib::MainContext::default().spawn_local(async move {
+        while let Ok(msg) = rx.recv().await {
+            if !msg {
+                callback(msg);
 
-            let ui_comp = crate::gui::GUI::new(widget_window.clone());
-            ui_comp.show_message(MessageType::Error, &dialog_text, "Error".to_string());
+                let ui_comp = crate::gui::GUI::new(widget_window.clone());
+                ui_comp.show_message(MessageType::Error, &dialog_text, "Error".to_string());
+            }
         }
-        glib::ControlFlow::Continue
     });
 }
 

--- a/src/pages/tweaks.rs
+++ b/src/pages/tweaks.rs
@@ -8,7 +8,6 @@ use std::str;
 use gtk::prelude::*;
 use subprocess::Exec;
 
-use async_channel;
 use glib::translate::FromGlib;
 use gtk::glib;
 


### PR DESCRIPTION
The build was failing due to a couple of issues and I started looking into them. This pull request addresses the first of them on deprecation warnings on glib::MainContext::channel being treated as errors in CI.

The fix does the following:
- Replaces all uses of the deprecated glib::MainContext::channel, glib::Sender and glib::Receiver with async_channel::unbounded() across actions.rs, cli_handler.rs, pages/mod.rs, pages/dns.rs and pages/tweaks.rs
- Migrates receiver handlers from rx.attach() to glib::MainContext::default().spawn_local() with an async while let receive loop
- Uses send_blocking() in background threads and try_send() in sync GTK main-thread callbacks.