### PR TITLE
refactor: rename CLI struct to ConsoleUI without changing behavior

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,23 +3,27 @@ use crate::{dns, tweak, utils};
 
 use clap::{Args, Parser, Subcommand};
 
-pub struct CLI;
+pub struct ConsoleUi;
 
-impl CLI {
+impl ConsoleUi {
     pub fn new() -> Self {
         Self {}
     }
 }
 
-impl UI for CLI {
+impl UI for ConsoleUi {
     fn show_message(&self, message_type: MessageType, message: &str, title: String) {
-        let type_str = match message_type {
-            MessageType::Info => "INFO",
-            MessageType::Warning => "WARNING",
-            MessageType::Error => "ERROR",
-        };
-        println!("[{type_str}] {title}: {message}");
+        println!("{}", format_message(message_type, message, &title));
     }
+}
+
+fn format_message(message_type: MessageType, message: &str, title: &str) -> String {
+    let type_str = match message_type {
+        MessageType::Info => "INFO",
+        MessageType::Warning => "WARNING",
+        MessageType::Error => "ERROR",
+    };
+    format!("[{type_str}] {title}: {message}")
 }
 
 pub fn run_command(command: &str, escalate: bool) -> bool {
@@ -122,4 +126,26 @@ pub enum AppToLaunch {
     PackageInstaller,
     /// Launch the `CachyOS` Kernel Manager
     KernelManager,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ui::MessageType;
+
+    #[test]
+    fn show_message_formats_correctly() {
+        assert_eq!(
+            format_message(MessageType::Info, "test message", "Title"),
+            "[INFO] Title: test message"
+        );
+        assert_eq!(
+            format_message(MessageType::Warning, "test message", "Title"),
+            "[WARNING] Title: test message"
+        );
+        assert_eq!(
+            format_message(MessageType::Error, "test message", "Title"),
+            "[ERROR] Title: test message"
+        );
+    }
 }

--- a/src/cli_handler.rs
+++ b/src/cli_handler.rs
@@ -61,7 +61,7 @@ pub fn handle_fix_command(action: FixAction) -> Result<()> {
     }
 
     while let Ok(msg) = rx.try_recv() {
-        let ui_comp = crate::cli::CLI::new();
+        let ui_comp = crate::cli::ConsoleUi::new();
         ui_comp.show_message(msg.msg_type, &msg.msg, msg.msg_type.to_string());
     }
     Ok(())
@@ -254,7 +254,7 @@ pub fn handle_dns_command(action: DnsAction) -> Result<()> {
         },
     }
     while let Ok(msg) = rx.try_recv() {
-        let ui_comp = crate::cli::CLI::new();
+        let ui_comp = crate::cli::ConsoleUi::new();
         ui_comp.show_message(msg.msg_type, &msg.msg, msg.msg_type.to_string());
     }
     Ok(())


### PR DESCRIPTION
Initially, I just wanted to address the following warning below by clippy and to change the CLI struct to Cli but we already had the Cli struct in cli.rs added by clap. That's pretty confusing. 

I've renamed CLI to ConsoleUi and added a test. No changing behavior was introduced.

@vnepogodin please review.

```
error: name `CLI` contains a capitalized acronym
 --> src/cli.rs:6:12
  |
6 | pub struct CLI;
  |            ^^^ help: consider making the acronym lowercase, except the initial letter: `Cli`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms
  = note: `-D clippy::upper-case-acronyms` implied by `-D warnings`
  = help: to override `-D warnings` add `#[allow(clippy::upper_case_acronyms)]`
```