### PR TITLE
fix(i18n): localize CachyOS app shortcuts and sync TR Fluent

### DIFF
--- a/i18n/tr/cachyos_hello.ftl
+++ b/i18n/tr/cachyos_hello.ftl
@@ -11,6 +11,12 @@ lock-doesnt-exist = Pacman veritabanı kilidi bulunmamaktadır!
 orphans-not-found = Hiçbir artık (orphan) paket bulunamadı!
 package-not-installed = '{$package_name}' paketi kurulmamıştır!
 gaming-package-installed = Oyun paketleri halihazırda kurulu!
+winboat-package-installed = Winboat paketleri zaten kurulu!
+vram-management-package-installed = VRAM yönetim paketleri zaten kurulu!
+
+# Tweaks page — quick launch (CachyOS apps)
+app-cachyos-pi-label = CachyOS Paket Kurucu
+app-cachyos-kernel-manager-label = CachyOS Çekirdek Yöneticisi
 
 # Application Browser page
 advanced-btn = gelişmiş
@@ -31,6 +37,9 @@ apply = Uygula
 reset = Sıfırla
 enable-dot = DNS over TLS (DoT) etkinleştir
 dot-tooltip = Daha iyi gizlilik için DNS sorgularını TLS ile şifrele (sunucu desteği gerektirir)
+enable-doh = HTTPS üzerinden DNS (DoH) etkinleştir
+doh-tooltip = Daha iyi gizlilik için DNS sorgularını yerel blocky vekil sunucusu üzerinden HTTPS ile şifrele (sunucu desteği gerektirir; blocky kurar)
+doh-blocky-install-failed = DoH desteği için blocky kurulamadı!
 test-latency = Seçili Sunucunun Gecikmesini Test Et
 test-latency-tooltip = Seçili DNS sunucusuna ağ gecikmesini ölç
 best-server = Gecikmeye Göre En İyi Sunucuyu Seç
@@ -40,11 +49,21 @@ server-info = {""}
 latency-testing = test ediliyor...
 latency-timeout = zaman aşımı
 latency-no-result = hiçbir sunucu yanıt vermedi
-dns-check-hint = Uyguladıktan sonra DNS sağlayıcınızı doğrulayın
+custom-dns = Özel
+dhcp-automatic = DHCP (otomatik)
+custom-dns-ipv4 = IPv4 adresleri (virgülle ayrılmış):
+custom-dns-ipv6 = IPv6 adresleri (virgülle ayrılmış):
+custom-dns-dot-hostname = DoT ana bilgisayar adı (isteğe bağlı):
+custom-dns-invalid = Lütfen en az bir IPv4 veya IPv6 adresi girin
+custom-dns-invalid-hostname = Geçersiz DoT ana bilgisayar adı
+custom-dns-doh-url = DoH URL’si (HTTPS üzerinden DNS için):
+custom-dns-doh-url-required = Lütfen https:// ile başlayan geçerli bir DoH URL’si girin
+dns-check-hint = Uyguladıktan sonra DNS sağlayıcınızı şu adreste doğrulayın:
 dns-server-changed = DNS sunucusu başarıyla değiştirildi!
 dns-server-failed = DNS sunucusu değiştirme işlemi başarısız oldu!
 dns-server-reset = DNS sunucusu eski haline getirildi!
 dns-server-reset-failed = DNS sunucusu sıfırlama işlemi başarısız oldu!
+winboat-install-failed = Winboat kurulamadı!
 
 # Tweaks page (tweaks)
 tweak-enabled-title = {$tweak} etkinleştirildi.
@@ -58,7 +77,7 @@ tweak-cachyupdate-tooltip = Güncelleme bildirim servisi
 # Tweaks page (fixes)
 remove-lock-title = Pacman veritabanı kilidini kaldır
 reinstall-title = Tüm paketleri yeniden kur
-reset-keyrings-title = Reset keyrings
+reset-keyrings-title = Anahtar halkalarını sıfırla
 update-system-title = Sistem güncellemesi
 remove-orphans-title = Artık (orphan) paketleri kaldır
 clear-pkgcache-title = Önbellekteki paketleri temizle
@@ -66,6 +85,9 @@ rankmirrors-title = Yansıları hıza göre sırala
 dnsserver-title = DNS sunucusunu değiştir
 show-kwinw-debug-title = KWin (Wayland) hata ayıklama penceresini göster
 install-gaming-title = Oyun paketlerini kur
+install-winboat-title = Winboat kur
+install-vram-management-title = VRAM yönetimini kur
+install-vram-management-tooltip = AMD veya Intel GPU’larda dmemcg-booster ve plasma-foreground-booster paketlerini kur
 
 # Main Page (buttons)
 button-about-tooltip = Hakkında


### PR DESCRIPTION
# Turkish localization changes


---

## 1. `i18n/tr/cachyos_hello.ftl`

**Goal:** Same **set of keys** as `i18n/en/cachyos_hello.ftl`, with a Turkish value for every key that was missing.

### 1.1 Keys that existed in `en` but not in `tr` (all added)

The following keys were added to `tr` to match English (summary of the Turkish copy):

| Key | Turkish UI (summary) |
|-----|----------------------|
| `winboat-package-installed` | Winboat packages already installed |
| `gpu-boosters-package-installed` | GPU booster packages already installed |
| `enable-doh` | Enable DNS over HTTPS (DoH) |
| `doh-tooltip` | DoH via local blocky proxy description |
| `doh-blocky-install-failed` | Failed to install blocky for DoH |
| `custom-dns` | Custom |
| `dhcp-automatic` | DHCP (automatic) |
| `custom-dns-ipv4` / `custom-dns-ipv6` | Comma-separated address field labels |
| `custom-dns-dot-hostname` | DoT hostname (optional) |
| `custom-dns-invalid` | Enter at least one IPv4 or IPv6 address |
| `custom-dns-invalid-hostname` | Invalid DoT hostname |
| `custom-dns-doh-url` / `custom-dns-doh-url-required` | DoH URL fields / valid `https://` URL |
| `dns-check-hint` | After applying, verify DNS provider at (text before URL) |
| `winboat-install-failed` | Failed to install Winboat |
| `reset-keyrings-title` | Reset keyrings (was left in English before) |
| `install-winboat-title` | Install Winboat |
| `install-gpu-boosters-title` | Install GPU boosters |
| `install-gpu-boosters-tooltip` | dmemcg-booster / plasma-foreground-booster on AMD or Intel GPUs |

### 1.2 Tweaks → Applications row (new)

| Key | Turkish UI |
|-----|------------|
| `app-cachyos-pi-label` | CachyOS Paket Kurucu |
| `app-cachyos-kernel-manager-label` | CachyOS Çekirdek Yöneticisi |

---

## 2. `i18n/en/cachyos_hello.ftl`

This block was added to the **fallback language** so keys exist for all locales (missing locales fall back to English):

```text
# Tweaks page — quick launch (CachyOS apps)
app-cachyos-pi-label = CachyOS Package Installer
app-cachyos-kernel-manager-label = CachyOS Kernel Manager
```

(Other DNS / Winboat / GPU / custom DNS strings were already in `en`; `tr` was brought in line with them.)

---

## 3. `src/pages/mod.rs` (works with translated button labels)

**Issue:** Buttons under “Applications” used **hard-coded English** labels. The old `on_appbtn_clicked` logic matched **button label text**; after localization the labels no longer matched, so clicks would break.

**Changes:**

- `create_gtk_button!("app-cachyos-pi-label")` and `create_gtk_button!("app-cachyos-kernel-manager-label")` — labels come entirely from Fluent.
- `spawn_cachyos_app("cachyos-pi")` and `spawn_cachyos_app("cachyos-kernel-manager")` — which binary to launch does **not** depend on the visible label, only on the fixed executable name.
- **`on_appbtn_clicked` was removed** so behavior is independent of Turkish vs English label text.

---

## 4. `src/pages/i18n.rs` (language switch updates the buttons)

**Issue:** Changing language from the menu did not refresh the two buttons on the Applications row.

**Change:** In `update_translation_apps_section`, the code walks the **horizontal box** after the “Applications” label and, for each `gtk::Button`, applies `widget_name` → `get_locale_text` → `set_label`.

---

## 5. `data/pages/tr/` (`readme` / `involved`)

**Not modified** in this work; Turkish page content was already aligned with `en`. If English pages change later, diff against `data/pages/en/` and sync `tr`.

---

## 6. Summary

| File | Role in Turkish localization |
|------|------------------------------|
| `i18n/tr/cachyos_hello.ftl` | All missing Fluent keys + application shortcut strings |
| `i18n/en/cachyos_hello.ftl` | New English keys for application shortcuts |
| `src/pages/mod.rs` | Labels from Fluent; click path safe for any language |
| `src/pages/i18n.rs` | Refresh application buttons when locale changes |

Fluent layout: `i18n.toml` (`fallback_language = "en"`, `assets_dir = "i18n"`).
