### PR TITLE
Fix: resolve language dropdown overflow

### DIFF
--- a/ui/cachyos-hello.glade
+++ b/ui/cachyos-hello.glade
@@ -280,6 +280,7 @@ We, the CachyOS Developers, hope that you will enjoy using CachyOS as much as we
                   <object class="GtkComboBoxText" id="languages">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="wrap-width">3</property>
                     <items>
                       <item id="en">English</item>
                       <!-- Keep en first -->


### PR DESCRIPTION
## Description
The language selection dropdown (`GtkComboBoxText`) in the CachyOS Hello interface exhibits an overflow bug when rendering long lists. Since the widget is positioned near the bottom of the window, GTK3 fails to calculate the popup geometry correctly, resulting in a solid container.

## Proposed Solution
Added the `wrap-width` property to the `languages` object within the `.glade` file. 

By setting **`wrap-width` to `3`**, the widget switches to a grid-based List Mode. This not only enables an internal scrollbar but also organizes the languages into three columns, which is visually more elegant.

---
## Visual Impact (Before & After)

### 🔴 Current Behavior (Bug)
| First Item | Intermediate Item | Last Item |
| :--- | :--- | :--- |
| <img width="1920" height="1080" alt="Overflow - First item" src="https://github.com/user-attachments/assets/4c49645d-27fc-4fb1-990f-f58ad0333042" /> | <img width="1920" height="1080" alt="Overflow - Intermediate item" src="https://github.com/user-attachments/assets/8c5902d1-8056-48bb-962d-5b2a872759c8" /> | <img width="1920" height="1080" alt="Overflow - Last item" src="https://github.com/user-attachments/assets/91aa0e3f-a3b6-4693-958f-bc4000f1869a" /> |

### 🟢 Proposed Fix
*The 3-column configuration was chosen for its superior elegance and efficient use of screen real estate.*

| 1 Column | 2 Columns | 3 Columns (fix) |
| :--- | :--- | :--- |
| <img width="1920" height="1080" alt="Fix - 1 Column" src="https://github.com/user-attachments/assets/18be2aab-81b5-47c3-8216-92bc7f12a2f4" /> | <img width="1920" height="1080" alt="Fix - 2 Column" src="https://github.com/user-attachments/assets/dded02ab-f120-4bd5-9d00-c25c3d80a704" /> | <img width="1920" height="1080" alt="Fix - 3 Column" src="https://github.com/user-attachments/assets/1deb4202-7ffa-4dbc-a982-32d6297b8a56" /> |

---

## Technical Notes
While a full migration to a `GtkPopover` or a custom `GtkScrolledWindow` implementation (potentially in Rust) would be the ideal structural fix for GTK3, this XML-only change provides an immediate, low-impact solution that fixes the UI regression without altering the application's logic.