### PR TITLE
Fix: Avoid SIGABRT if cachyos-pi is not available when clicking "Install Apps"

### DIFF
--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -285,7 +285,9 @@ pub fn create_appbrowser_page(builder: &Builder) {
         // Spawn child process in separate thread.
         std::thread::spawn(move || {
             // Get executable path.
-            let exec_path = utils::get_cachyos_pi_path().expect("Did not find cachyos-pi");
+            // TODO(vnepogodin): prompt to install if it doesn't exist
+            let exec_path = utils::get_cachyos_pi_path().expect("cachyos-pi not found");
+            let exit_status = utils::spawn_detached(&exec_path).expect("Failed to spawn process");
             let exit_status = utils::spawn_detached(exec_path.as_str()).expect("Failed to spawn process");
 
             debug!("Exit status successfully? = {:?}", exit_status.success());

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -279,7 +279,7 @@ pub fn create_tweaks_page(builder: &Builder) {
 
 pub fn create_appbrowser_page(builder: &Builder) {
     let install: gtk::Button = builder.object("appBrowser").unwrap();
-    install.set_visible(true);
+    install.set_visible(utils::is_cachyos_pi_installed());
     install.set_label(&fl!("appbrowser-label"));
     install.connect_clicked(move |_| {
         // Spawn child process in separate thread.

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -288,8 +288,6 @@ pub fn create_appbrowser_page(builder: &Builder) {
             // TODO(vnepogodin): prompt to install if it doesn't exist
             let exec_path = utils::get_cachyos_pi_path().expect("cachyos-pi not found");
             let exit_status = utils::spawn_detached(&exec_path).expect("Failed to spawn process");
-            let exit_status = utils::spawn_detached(exec_path.as_str()).expect("Failed to spawn process");
-
             debug!("Exit status successfully? = {:?}", exit_status.success());
         });
     });

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -196,7 +196,7 @@ fn create_apps_section() -> Option<gtk::Box> {
     label.set_text(&fl!("applications"));
 
     // Check first btn.
-    if Path::new("/sbin/cachyos-pi").exists() {
+    if utils::is_cachyos_pi_installed() {
         let cachyos_pi = gtk::Button::with_label("CachyOS PackageInstaller");
         cachyos_pi.connect_clicked(on_appbtn_clicked);
         box_collection.pack_start(&cachyos_pi, true, true, 2);
@@ -285,8 +285,8 @@ pub fn create_appbrowser_page(builder: &Builder) {
         // Spawn child process in separate thread.
         std::thread::spawn(move || {
             // Get executable path.
-            let exec_path = "/usr/bin/cachyos-pi";
-            let exit_status = utils::spawn_detached(exec_path).expect("Failed to spawn process");
+            let exec_path = utils::get_cachyos_pi_path().expect("Did not find cachyos-pi");
+            let exit_status = utils::spawn_detached(exec_path.as_str()).expect("Failed to spawn process");
 
             debug!("Exit status successfully? = {:?}", exit_status.success());
         });

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -166,7 +166,7 @@ pub fn is_alpm_pkg_installed(package_name: &str) -> bool {
 }
 
 pub fn get_cachyos_pi_path() -> Option<String> {
-    if Path::new("/usr/bin/cachyos-pi").exists() {
+    which::which("cachyos-pi").ok().map(|p| p.to_string_lossy().into_owned())
         Some("/usr/bin/cachyos-pi");
     }
     if Path::new("/sbin/cachyos-pi").exists() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -167,12 +167,6 @@ pub fn is_alpm_pkg_installed(package_name: &str) -> bool {
 
 pub fn get_cachyos_pi_path() -> Option<String> {
     which::which("cachyos-pi").ok().map(|p| p.to_string_lossy().into_owned())
-        Some("/usr/bin/cachyos-pi");
-    }
-    if Path::new("/sbin/cachyos-pi").exists() {
-        Some("/sbin/cachyos-pi");
-    }
-    None
 }
 
 pub fn is_cachyos_pi_installed() -> bool {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -165,6 +165,20 @@ pub fn is_alpm_pkg_installed(package_name: &str) -> bool {
     alpm.localdb().pkg(package_name.as_bytes()).is_ok()
 }
 
+pub fn get_cachyos_pi_path() -> Option<String> {
+    if Path::new("/usr/bin/cachyos-pi").exists() {
+        Some("/usr/bin/cachyos-pi");
+    }
+    if Path::new("/sbin/cachyos-pi").exists() {
+        Some("/sbin/cachyos-pi");
+    }
+    None
+}
+
+pub fn is_cachyos_pi_installed() -> bool {
+    get_cachyos_pi_path().is_some()
+}
+
 pub fn is_intel_amd_gpu(vendor_id: &str, class_id: &str) -> bool {
     const GPU_CLASS_IDS: &[&str] = &["0300"];
     const VENDOR_IDS: &[&str] = &["8086", "1002"];


### PR DESCRIPTION
Hello panics if the user clicks "Install Apps" and cachyos-pi is not found at /usr/bin/cachyos-pi.

This PR solves this by hiding the button if cachyos-pi is not available, and also makes cachyos-pi detection more consistent (another place looked for /sbin/cachyos-pi instead).