### PR TITLE
Add a Quickinstaller for Office Utils to the Apps/Tweaks menu

### DIFF
--- a/i18n/de/cachyos_hello.ftl
+++ b/i18n/de/cachyos_hello.ftl
@@ -10,6 +10,7 @@ removed-db-lock = Pacman db lock wurde entfernt!
 lock-doesnt-exist = Pacman db lock existiert nicht!
 orphans-not-found = Keine verwaisten Pakete gefunden!
 package-not-installed = Das Paket '{$package_name}' wurde nicht installiert!
+office-package-installed = Office Pakete bereits installiert!
 
 # Dns Connections page
 dns-settings = DNS Einstellung
@@ -45,6 +46,7 @@ remove-orphans-title = Nicht verwendete Pakete entfernen
 clear-pkgcache-title = Paket-Cache löschen
 rankmirrors-title = Rank Mirrors
 dnsserver-title = DNS-Server ändern
+install-office-title = Office Programme installieren
 
 # Main Page (buttons)
 button-about-tooltip = Über

--- a/i18n/en/cachyos_hello.ftl
+++ b/i18n/en/cachyos_hello.ftl
@@ -11,6 +11,7 @@ lock-doesnt-exist = Pacman db lock does not exist!
 orphans-not-found = No orphan packages found!
 package-not-installed = Package '{$package_name}' has not been installed!
 gaming-package-installed = Gaming packages already installed!
+office-package-installed = Office packages already installed!
 winboat-package-installed = Winboat packages already installed!
 vram-management-package-installed = VRAM management packages already installed!
 
@@ -81,6 +82,7 @@ rankmirrors-title = Rank mirrors
 dnsserver-title = Change DNS server
 show-kwinw-debug-title = Show kwin(Wayland) debug window
 install-gaming-title = Install Gaming packages
+install-office-title = Install Office packages
 install-winboat-title = Install Winboat
 install-vram-management-title = Install VRAM Management
 install-vram-management-tooltip = Prioritize VRAM for the foreground application so the GPU driver avoids spilling buffers into system RAM (GTT).

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -404,6 +404,17 @@ pub fn install_gaming(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage>
     );
 }
 
+pub fn install_office(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage>) {
+    const ALPM_PACKAGE_NAMES: [&str; 3] = ["libreoffice-fresh", "hunspell", "okular"];
+    install_needed_packages(
+        callback,
+        &ALPM_PACKAGE_NAMES,
+        fl!("office-package-installed"),
+        Action::InstallOffice,
+        dialog_tx,
+    );
+}
+
 pub fn install_vram_management(callback: RunCmdCallback, dialog_tx: Sender<DialogMessage>) {
     let mut packages: Vec<&str> = vec!["dmemcg-booster"];
     if utils::is_kwin_wayland() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,6 +76,8 @@ pub enum FixAction {
     RankMirrors,
     /// Install `CachyOS` gaming meta-packages
     InstallGaming,
+    /// Install Office packages like LibreOffice
+    InstallOffice,
     /// Show the `KWin` Wayland debug console (if running)
     ShowKwinDebug,
     /// Install Winboat for Windows applications

--- a/src/cli_handler.rs
+++ b/src/cli_handler.rs
@@ -46,6 +46,10 @@ pub fn handle_fix_command(action: FixAction) -> Result<()> {
             println!("{}", "Installing CachyOS gaming packages...".bold());
             actions::install_gaming(crate::cli::run_command, tx);
         },
+        FixAction::InstallOffice => {
+            println!("{}", "Installing Office packages...".bold());
+            actions::install_office(crate::cli::run_command, tx);
+        },
         FixAction::ShowKwinDebug => {
             println!("{}", "Attempting to launch KWin debug console...".bold());
             actions::launch_kwin_debug_window();

--- a/src/pages/mod.rs
+++ b/src/pages/mod.rs
@@ -43,6 +43,7 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
     let rankmirrors_btn = create_gtk_button!("rankmirrors-title");
 
     let install_gaming_btn = create_gtk_button!("install-gaming-title");
+    let install_office_btn = create_gtk_button!("install-office-title");
     let install_winboat_btn = create_gtk_button!("install-winboat-title");
     let install_vram_management_btn = utils::has_intel_or_amd_gpu().then(|| {
         let btn = create_gtk_button!("install-vram-management-title");
@@ -56,6 +57,7 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
     // Connect signals.
     let dialog_tx_clone = dialog_tx.clone();
     let dialog_tx_gaming = dialog_tx.clone();
+    let dialog_tx_office = dialog_tx.clone();
     let dialog_tx_winboat = dialog_tx.clone();
     let dialog_tx_vram_management = dialog_tx.clone();
     removelock_btn.connect_clicked(move |_| {
@@ -93,6 +95,13 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
             actions::install_gaming(crate::gui::run_command, dialog_tx_gaming);
         });
     });
+    install_office_btn.connect_clicked(move |_| {
+        // Spawn child process in separate thread.
+        let dialog_tx_office = dialog_tx_office.clone();
+        std::thread::spawn(move || {
+            actions::install_office(crate::gui::run_command, dialog_tx_office);
+        });
+    });
     install_winboat_btn.connect_clicked(move |_| {
         // Spawn child process in separate thread.
         let dialog_tx_winboat = dialog_tx_winboat.clone();
@@ -116,6 +125,7 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
     let removelock_btn_clone = removelock_btn.clone();
     let remove_orphans_btn_clone = remove_orphans_btn.clone();
     let install_gaming_btn_clone = install_gaming_btn.clone();
+    let install_office_btn_clone = install_office_btn.clone();
     let install_winboat_btn_clone = install_winboat_btn.clone();
     let install_vram_management_btn_clone = install_vram_management_btn.clone();
     glib::MainContext::default().spawn_local(async move {
@@ -124,6 +134,7 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
                 Action::RemoveLock => &removelock_btn_clone,
                 Action::RemoveOrphans => &remove_orphans_btn_clone,
                 Action::InstallGaming => &install_gaming_btn_clone,
+                Action::InstallOffice => &install_office_btn_clone,
                 Action::InstallWinboat => &install_winboat_btn_clone,
                 Action::InstallVramManagement => install_vram_management_btn_clone
                     .as_ref()
@@ -147,6 +158,7 @@ fn create_fixes_section(builder: &Builder) -> gtk::Box {
     button_box_s.pack_end(&remove_orphans_btn, true, true, 2);
     button_box_t.pack_end(&rankmirrors_btn, true, true, 2);
     button_box_t.pack_end(&install_gaming_btn, true, true, 2);
+    button_box_t.pack_end(&install_office_btn, true, true, 2);
     button_box_t.pack_end(&install_winboat_btn, true, true, 2);
     if let Some(button) = &install_vram_management_btn {
         button_box_frth.pack_end(button, true, true, 2);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -30,6 +30,7 @@ pub enum Action {
     RemoveOrphans,
     SetDnsServer,
     InstallGaming,
+    InstallOffice,
     InstallWinboat,
     InstallVramManagement,
 }


### PR DESCRIPTION
I added a Quickinstaller for Office Utils to the Apps/Tweaks menu.

This installation command installs the following packages:
- `libreoffice-fresh` (Office programmes)
- `hunspell` (autocorrection);
- okular (PDF viewer).

It also adds DE and EN translations for the corresponding button and the success notification.