### PR TITLE
i18n(de): Update and optimize German translations 

### DIFF
--- a/i18n/de/cachyos_hello.ftl
+++ b/i18n/de/cachyos_hello.ftl
@@ -3,22 +3,28 @@ about-dialog-title = CachyOS Hello
 about-dialog-comments = Willkommensdialog für CachyOS
 
 # Tweaks page
-tweaks = Tweaks
+tweaks = Optimierungen
 fixes = Dienstprogramme
 applications = Anwendungen
 removed-db-lock = Pacman db lock wurde entfernt!
 lock-doesnt-exist = Pacman db lock existiert nicht!
 orphans-not-found = Keine verwaisten Pakete gefunden!
 package-not-installed = Das Paket '{$package_name}' wurde nicht installiert!
+gaming-package-installed = Gaming-Pakete sind schon installiert!
+winboat-package-installed = Winboat-Pakete sind schon installiert!
+vram-management-package-installed = VRAM-Verwaltungspakete sind schon installiert!
 
 # Dns Connections page
 dns-settings = DNS Einstellung
 select-connection = Verbindung auswählen:
 select-dns-server = DNS-Server auswählen:
 apply = Anwenden
-reset = Reset
+reset = Zurücksetzen
 enable-dot = DNS über TLS (DoT) aktivieren
 dot-tooltip = DNS-Anfragen mit TLS verschlüsseln für besseren Datenschutz (erfordert Serverunterstützung)
+enable-doh = DNS über HTTPS (DoH) aktivieren
+doh-tooltip = DNS-Anfragen mit HTTPS über einen lokalen blocky-Proxy verschlüsseln (erfordert Serverunterstützung, installiert blocky)
+doh-blocky-install-failed = Die Installation von blocky für DoH-Unterstützung ist fehlgeschlagen!
 test-latency = Latenz des ausgewählten Servers testen
 test-latency-tooltip = Netzwerklatenz zum ausgewählten DNS-Server messen
 best-server = Besten Server nach Latenz wählen
@@ -38,13 +44,19 @@ dns-server-reset-failed = DNS-Server konnte nicht zurückgesetzt werden!
 tweak-enabled-title = {$tweak} aktiviert
 
 # Tweaks page (fixes)
-remove-lock-title = Entferne Datenbanksperre
+remove-lock-title = Datenbanksperre entfernen
 reinstall-title = Alle Pakete neu installieren
+reset-keyrings-title = Keyrings zurücksetzen
 update-system-title = System-Aktualisierung
 remove-orphans-title = Nicht verwendete Pakete entfernen
 clear-pkgcache-title = Paket-Cache löschen
-rankmirrors-title = Rank Mirrors
+rankmirrors-title = Spiegelserver (Mirrors) bewerten
 dnsserver-title = DNS-Server ändern
+show-kwinw-debug-title = kwin(Wayland)-Debug-Fenster anzeigen
+install-gaming-title = Gaming-Pakete installieren
+install-winboat-title = Winboat installieren
+install-vram-management-title = VRAM-Verwaltung installieren
+install-vram-management-tooltip = Priorisiere VRAM für die Vordergrundanwendung, damit der GPU-Treiber das Auslagern von Puffern in den System-RAM (GTT) vermeidet.
 
 # Main Page (buttons)
 button-about-tooltip = Über
@@ -67,15 +79,15 @@ section-project = PROJEKT
 
 # Main Page (body)
 offline-error = Die Online-Installation kann nicht gestartet werden! Keine Internetverbindung
-unsupported-hw-warning = Sie versuchen, die Installation auf einer Hardware durchzuführen, die von der aktuellen ISO nicht unterstützt wird, und können daher keinen Support in Anspruch nehmen
-desktop-on-handheld-error = Sie versuchen, die Desktop-Edition auf einem Handheld-Gerät zu installieren. Bitte verwenden Sie die Handheld-Edition für ordnungsgemäße Unterstützung auf dieser Hardware
+unsupported-hw-warning = Du versuchst, die Installation auf einer Hardware durchzuführen, die von der aktuellen ISO nicht unterstützt wird, und können daher keinen Support in Anspruch nehmen
+desktop-on-handheld-error = Du versuchst, die Desktop-Edition auf einem Handheld-Gerät zu installieren. Bitte verwende die Handheld-Edition für ordnungsgemäße Unterstützung auf dieser Hardware
 outdated-version-warning = Du nutzt eine alte Version von CachyOS, bitte downloade die letzte Version runter
 testing-iso-warning = Du verwendest eine alte Testing ISO, Testing-ISOs sind nicht stabil und getestet
-tweaksbrowser-label = Apps/Tweaks
+tweaksbrowser-label = Apps/Optimierungen
 appbrowser-label = Apps installieren
 launch-start-label = Beim Systemstart ausführen
 welcome-title = Willkommen bei CachyOS!
 welcome-body =
-    Danke, dass Sie sich unserer Community anschließen!
+    Danke, dass du dich unserer Community anschließt!
 
-    Wir, die CachyOS-Entwickler, hoffen, dass Sie es genauso sehr genießen werden CachyOS zu benutzen, wie wir es genießen, es zu entwickeln. Die Links unten werden Ihnen helfen sich in Ihrem neuen Betriebssystem zurechtzufinden. Genießen Sie diese Erfahrung und zögern Sie nicht Ihr Feedback an uns zu senden.
+    Wir, die CachyOS-Entwickler, hoffen, dass du es genauso sehr genießen wirst, CachyOS zu benutzen, wie wir es genießen, es zu entwickeln. Die Links unten werden dir helfen dich in deinem neuen Betriebssystem zurechtzufinden. Genieße diese Erfahrung und zögere nicht dein Feedback an uns zu senden.


### PR DESCRIPTION
This PR updates and refines some German (`de`) locale keys for CachyOS Hello. Some missing translations have been added. Additionally, some keys missing from the English `(en)` locale have been added.

## Changes made:
- **Tone adjustment:** Formal strings were converted into a modern, informal, peer-to-peer tone to match the tone used throughout the locale.
- **Updated / translated strings:** Strings such as `Reset` that were not translated into German were translated into German vocabulary. Other strings in German were updated to sound more accurate and natural.
- **Added some missing keys:** Some keys that were not found in the German locale have been imported from the English locale and translated.

## How to test:
You can launch the app locally forced into the German locale to verify translations:
`LANG=de_DE.UTF-8 cargo run` _(you may also just select the German locale in the languages drop-down menu)_

**Local translations have been verified using `cargo run`.** 

## Additional notes
- As stated in a comment I made on my commit, this PR is a partial translation and does not include all the missing keys I found in the English locale.
- **I am also seeing an issue with the CI that is causing some PRs to fail due to an error reported in the CI log. [*Example*](https://github.com/CachyOS/CachyOS-Welcome/actions/runs/26318654887/job/77483122850?pr=253)**