### PR TITLE
terminal-helper: Honor $TERMINAL and harden terminal launching

### DIFF
--- a/src/scripts/terminal-helper
+++ b/src/scripts/terminal-helper
@@ -14,7 +14,6 @@
 # 3. The terminal emulator with best accessibility comes first.
 # 4. No order is guaranteed/desired for the remaining terminal emulators.
 
-set -e
 LAUNCHER_CMD=bash
 
 usage() {
@@ -40,8 +39,11 @@ done
 # OPTIND is a global variable
 shift $((OPTIND - 1))
 
-file="$(mktemp)"
-echo "$1" >"$file"
+file="$(mktemp)" || exit 1
+echo "$1" >"$file" || {
+    rm "$file"
+    exit 1
+}
 cmd="${LAUNCHER_CMD} \"$file\""
 echo "$cmd"
 
@@ -52,7 +54,7 @@ declare -A terminals=(
     ["ghostty"]="ghostty -e $cmd"
     ["kgx"]="kgx --wait -e $cmd"
     ["gnome-terminal"]="gnome-terminal --wait -- $cmd"
-    ["kitty"]="kitty $cmd"
+    ["kitty"]="kitty --wait-for-single-instance-window-close $cmd"
     ["wezterm"]="wezterm start --always-new-process $cmd"
     ["konsole"]="konsole -e $cmd"
     ["lxterminal"]="lxterminal -e $cmd"
@@ -61,7 +63,7 @@ declare -A terminals=(
     ["terminator"]="terminator -x $cmd"
     ["xfce4-terminal"]="xfce4-terminal --disable-server --command '$cmd'"
     ["xterm"]="xterm -e $cmd"
-    ["ptyxis"]="ptyxis -e $cmd"
+    ["ptyxis"]="ptyxis -- $cmd"
 )
 declare -a term_order=(
     "alacritty"
@@ -82,27 +84,63 @@ declare -a term_order=(
 
 )
 
-if [ -z "$terminal" ] || ! command -v "$terminal" &>/dev/null; then
-    for entry in "${term_order[@]}"; do
-        if command -v "$entry" >/dev/null 2>&1; then
-            # gnome-console does not exit on command completion so we need to kill
-            # it manually
-            [[ "$entry" == "kgx" ]] && echo "kill -SIGQUIT \$PPID 2>/dev/null" >> "$file"
-            terminal="$entry"
-            break
-        fi
-    done
+# 1. $TERMINAL must come first (per invariants)
+if [ -n "$TERMINAL" ] && [[ -n "${terminals[$TERMINAL]+_}" ]] && command -v "$TERMINAL" &>/dev/null; then
+    terminal="$TERMINAL"
 fi
 
-if [ -z "$terminal" ]; then
+# Ordered candidates: $TERMINAL first, then the known terminals that are
+# installed. Launch failures fall through to the next candidate.
+declare -a candidates=()
+if [ -n "$terminal" ]; then
+    candidates+=("$terminal")
+fi
+for entry in "${term_order[@]}"; do
+    [[ "$entry" == "$terminal" ]] && continue
+    command -v "$entry" >/dev/null 2>&1 && candidates+=("$entry")
+done
+
+if [ ${#candidates[@]} -eq 0 ]; then
+    rm "$file"
     notify-send -t 1500 --app-name=CachyOS "No terminal installed" "Could not find a terminal emulator. Please install one."
     exit 1
 fi
 
-eval "${terminals[${terminal}]}" 2>/dev/null || {
-    if [[ "$terminal" != "kgx" ]]; then
+failed=1
+for entry in "${candidates[@]}"; do
+    # Rewrite the script file so a failed attempt doesn't leave terminal
+    # specific lines (e.g. the kgx kill) behind for the next candidate.
+    echo "$1" >"$file" || {
         rm "$file"
-        exit 2
+        exit 1
+    }
+    if [[ "$entry" == "kgx" ]]; then
+        # gnome-console does not exit on command completion so we need to kill
+        # it manually
+        echo '(( PPID > 1 )) && kill -SIGQUIT $PPID 2>/dev/null' >>"$file"
     fi
-}
+    # Normalize the shell exit status: some terminals (foot, st) propagate
+    # it, and a failed command must not be mistaken for a failed launch.
+    echo 'exit 0' >>"$file"
+
+    eval "${terminals[$entry]}" 2>/dev/null
+    rc=$?
+    # kgx is killed by the line above after the command completes, which
+    # shows up as exit status 131; treat that as a successful launch.
+    if [[ $rc -eq 0 ]] || { [[ "$entry" == "kgx" ]] && [[ $rc -eq 131 ]]; }; then
+        failed=0
+        break
+    fi
+    # 126/127 mean the command was canceled or not authorized (e.g. the user
+    # dismissed the pkexec prompt) — retrying would just prompt again.
+    if [[ $rc -eq 126 ]] || [[ $rc -eq 127 ]]; then
+        break
+    fi
+done
+
 rm "$file"
+
+if ((failed)); then
+    notify-send -t 1500 --app-name=CachyOS "Failed to launch terminal" "Could not start a terminal emulator to run the command."
+    exit 2
+fi


### PR DESCRIPTION
Summary                                                                                                                
                                                                                                                        
terminal-helper documented $TERMINAL as the first-priority terminal (see the invariants comment), but never actually read it. The script always fell back to the hardcoded term_order list, so users' preferred terminal was ignored.      
                                                                                                                        
Honoring $TERMINAL makes every entry in the terminals map reachable, which exposed several latent issues in those previously untested code paths. This PR fixes them all.                                                    
                                                                                                                        
Changes                                                                                                                
                                                                                                                        
- Honor $TERMINAL — checked first, but only when the value is a known terminal from the terminals map (guarantees the correct invocation syntax) and the binary exists. Invalid/stale values fall back to term_order as before.            
- ptyxis: ptyxis -e … → ptyxis -- … — ptyxis has no -e option; -- PROGRAM is the documented form and implies   standalone mode (no detached client).                                                                                
- kitty: added --wait-for-single-instance-window-close — previously, with a running kitty instance, the client rocess   exited immediately and the temp script could be deleted before the new window read it.                               
- Launch fallback chain — candidates are tried in order ($TERMINAL first, then installed terminals in term_order). If a launch fails, the next candidate is tried; retrying stops on exit codes 126/127 (e.g. the user dismissed the   pkexec prompt), and if no terminal launches at all a desktop notification is shown and the script exits 2.           
- Exit-code normalization — exit 0 is appended to the temp script. Terminals like foot and st propagate the child's   exit status, which must not be mistaken for a launch failure (previously this would have re-run the command in the next terminal).                                                                                                      
- kgx — the kill command is now also appended when $TERMINAL=kgx, guarded against $PPID == 1, and exit status 131 (killed by SIGQUIT after completion) is treated as a successful launch instead of a failure.                         
- Robustness — explicit aborts on mktemp/write failures (replacing the removed set -e), and the temp file is cleaned up on every path, including the "no terminal installed" path that previously leaked it.                              
                                                                                                                        
 Notes                                                                                                                  
                                                                                                                        
 - With escalate=true, real pkexec forks, so kgx's kill line targets the pkexec wrapper rather than the terminal — the window may stay open after the command finishes. Cosmetic only; the command itself has already completed.            