### PR TITLE
terminal-helper: remove scripts after execution

### DIFF
--- a/src/scripts/terminal-helper
+++ b/src/scripts/terminal-helper
@@ -41,7 +41,7 @@ done
 shift $((OPTIND - 1))
 
 file="$(mktemp)"
-echo "$1" >"$file"
+printf '%s\n' "$1" >"$file"
 cmd="${LAUNCHER_CMD} \"$file\""
 echo "$cmd"
 
@@ -99,10 +99,10 @@ if [ -z "$terminal" ]; then
     exit 1
 fi
 
+printf 'rm -f -- %q\n' "$file" >>"$file"
 eval "${terminals[${terminal}]}" 2>/dev/null || {
     if [[ "$terminal" != "kgx" ]]; then
         rm "$file"
         exit 2
     fi
 }
-rm "$file"


### PR DESCRIPTION
## Summary
- retain generated terminal scripts until the shell running them finishes
- perform cleanup from the generated script itself
- retain immediate cleanup when a non-KGX terminal fails to launch

This fixes the race where GNOME Console can let the helper exit and delete the script before `pkexec` starts it.

Closes #287

## Validation
- `bash -n src/scripts/terminal-helper`
- exercised successful execution with a mock `alacritty` and verified the command completed and the temporary script was removed afterwards
- `git diff --check`